### PR TITLE
Add item macro support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,17 @@ Each 5etools data array "key" (aka "property", "prop"), e.g. `"monster"`, `"spel
 Within that directory, a `__core.json` file should contain effects/etc. data for all entities which are natively available on 5etools (i.e., without loading homebrew).
 
 Also within that directory, homebrew sources should each be given their own file, named `<brewSourceJson>.json`.
+
+### Item Macros
+
+Item macros are stored as JavaScript files, and built into the data when the module is packaged. The source for these macros can be found in the [macro-item](./macro-item) directory. **Note that the first and last lines of the macro are stripped when the macro is compiled into the module's data.**
+
+A new macro can be created using the following command:
+
+```bash
+# ex:
+# npm run mt -- -d spell -s PHB -n "Fireball"
+npm run mt -- -d <directory> -s <jsonSource> -n <entityName>
+```
+
+The directory (`-d`) should match that of the JSON file into which the macro will be built. The macro can then be referenced from within a JSON file by using: `"itemMacro": "<filename>"` (`"itemMacro": "PHB_fireball.js"` in the example given above)

--- a/macro-item/spell/XGE_toll-the-dead.js
+++ b/macro-item/spell/XGE_toll-the-dead.js
@@ -1,0 +1,12 @@
+async function macro (args) {
+	// From "MidiQOL Sample Items" compendium
+	if (args[0].macroPass !== "preDamageRoll") return;
+
+	const target = await fromUuid(args[0].targetUuids[0]);
+	const needsD12 = target.actor.data.data.attributes.hp.value < target.actor.data.data.attributes.hp.max;
+	const theItem = await fromUuid(args[0].uuid);
+	let formula = theItem.data.data.damage.parts[0][0];
+	if (needsD12) formula = formula.replace("d8", "d12");
+	else formula = formula.replace("d12", "d8");
+	theItem.data.data.damage.parts[0][0] = formula;
+}

--- a/module/data/spell/__core.json
+++ b/module/data/spell/__core.json
@@ -207,6 +207,21 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "Toll the Dead",
+			"source": "XGE",
+			"data": {
+				"damage.parts": [
+					[
+						"1d8",
+						"necrotic"
+					]
+				],
+				"damage.versatile": "",
+				"scaling.mode": "cantrip"
+			},
+			"itemMacro": "XGE_toll-the-dead.js"
 		}
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@league-of-foundry-developers/foundry-vtt-types": "^9.249.4",
-				"5etools-utils": "^0.1.14",
+				"@league-of-foundry-developers/foundry-vtt-types": "^9.269.0",
+				"5etools-utils": "^0.1.21",
 				"adm-zip-giddy": "^0.4.12",
 				"ajv": "^8.10.0",
 				"commander": "^9.1.0",
@@ -83,9 +83,9 @@
 			"dev": true
 		},
 		"node_modules/@league-of-foundry-developers/foundry-vtt-types": {
-			"version": "9.268.0",
-			"resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-9.268.0.tgz",
-			"integrity": "sha512-/rDUEdClBvlsVgKX8YRNBVGeK0zBlYy5DpMKHMXiJMqKFQV2TLecR0Y6u0tQWlo8BEea+yLkYr34stR3zCk0/A==",
+			"version": "9.269.0",
+			"resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-9.269.0.tgz",
+			"integrity": "sha512-M/rz86decPLXet9e6+bi0dm8WSGrT/5MM1QXUMEC7Z8vfKB9Y5D61B1J5laaqb3DdjVDS1kZtQEW3/sPg3EALw==",
 			"dev": true,
 			"dependencies": {
 				"@pixi/graphics-smooth": "0.0.22",
@@ -2266,9 +2266,9 @@
 			"dev": true
 		},
 		"node_modules/5etools-utils": {
-			"version": "0.1.14",
-			"resolved": "https://registry.npmjs.org/5etools-utils/-/5etools-utils-0.1.14.tgz",
-			"integrity": "sha512-sr5qfKPWglJXGCuYYxUOYxxrvmLRFNiZNYwg7Cr1rIx+mV1dCaZ97/Efs+KW5FOGxjhWsSKc3osst39Ba3uo5A==",
+			"version": "0.1.21",
+			"resolved": "https://registry.npmjs.org/5etools-utils/-/5etools-utils-0.1.21.tgz",
+			"integrity": "sha512-wOqVSRvd6h6H+SiNAFxrceZ35yyeV0LbAQ8lpSN/dv5IZ9fVqQSFMLNgM0Fa2Kl4fC9kLk8vp3XqZ2nvuw0wqA==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^8.11.0",
@@ -4346,9 +4346,9 @@
 			"dev": true
 		},
 		"@league-of-foundry-developers/foundry-vtt-types": {
-			"version": "9.268.0",
-			"resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-9.268.0.tgz",
-			"integrity": "sha512-/rDUEdClBvlsVgKX8YRNBVGeK0zBlYy5DpMKHMXiJMqKFQV2TLecR0Y6u0tQWlo8BEea+yLkYr34stR3zCk0/A==",
+			"version": "9.269.0",
+			"resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-9.269.0.tgz",
+			"integrity": "sha512-M/rz86decPLXet9e6+bi0dm8WSGrT/5MM1QXUMEC7Z8vfKB9Y5D61B1J5laaqb3DdjVDS1kZtQEW3/sPg3EALw==",
 			"dev": true,
 			"requires": {
 				"@pixi/graphics-smooth": "0.0.22",
@@ -6444,9 +6444,9 @@
 			"dev": true
 		},
 		"5etools-utils": {
-			"version": "0.1.14",
-			"resolved": "https://registry.npmjs.org/5etools-utils/-/5etools-utils-0.1.14.tgz",
-			"integrity": "sha512-sr5qfKPWglJXGCuYYxUOYxxrvmLRFNiZNYwg7Cr1rIx+mV1dCaZ97/Efs+KW5FOGxjhWsSKc3osst39Ba3uo5A==",
+			"version": "0.1.21",
+			"resolved": "https://registry.npmjs.org/5etools-utils/-/5etools-utils-0.1.21.tgz",
+			"integrity": "sha512-wOqVSRvd6h6H+SiNAFxrceZ35yyeV0LbAQ8lpSN/dv5IZ9fVqQSFMLNgM0Fa2Kl4fC9kLk8vp3XqZ2nvuw0wqA==",
 			"dev": true,
 			"requires": {
 				"ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
 	"type": "module",
 	"license": "MIT",
 	"scripts": {
-		"test:js": "eslint script module/js module/shared tool test",
-		"lint:js": "eslint script module/js module/shared tool test --fix",
+		"test:js": "eslint script module/js module/shared tool test macro-item",
+		"lint:js": "eslint script module/js module/shared tool test macro-item --fix",
 		"test:data": "node test/test-json.js && node test/test-data.js",
 		"lint:data": "node test/test-data.js --fix",
 		"test": "npm run test:data && npm run test:js",
@@ -15,11 +15,13 @@
 		"build:module": "node script/build.js",
 		"build": "npm run build:index && npm run build:module",
 		"package": "node script/package.js",
-		"tools": "node tool/server.js"
+		"tools": "node tool/server.js",
+		"macro-template": "node script/generate-item-macro-template.js",
+		"mt": "npm run macro-template --"
 	},
 	"devDependencies": {
-		"@league-of-foundry-developers/foundry-vtt-types": "^9.249.4",
-		"5etools-utils": "^0.1.14",
+		"@league-of-foundry-developers/foundry-vtt-types": "^9.269.0",
+		"5etools-utils": "^0.1.21",
 		"adm-zip-giddy": "^0.4.12",
 		"ajv": "^8.10.0",
 		"commander": "^9.1.0",

--- a/script/consts.js
+++ b/script/consts.js
@@ -1,0 +1,1 @@
+export const DIR_ITEM_MACROS = "macro-item";

--- a/script/generate-item-macro-template.js
+++ b/script/generate-item-macro-template.js
@@ -1,0 +1,40 @@
+import * as fs from "fs";
+import {Um} from "5etools-utils";
+import { Command } from "commander";
+import path from "path";
+import {DIR_ITEM_MACROS} from "./consts.js";
+
+const MACRO_TEMPLATE = `async function macro (args) {
+	// TODO write your macro here!
+}
+`;
+
+const program = new Command()
+	.requiredOption("-d, --dir <dir>", `Macro directory, e.g. "spell"`)
+	.requiredOption("-s, --source <source>", `JSON source, e.g. "PHB"`)
+	.requiredOption("-n, --name <name>", `Item name, e.g. "Fireball"`)
+;
+
+program.parse(process.argv);
+const params = program.opts();
+
+function main () {
+	if (params.dir.replace(/[^a-zA-Z]+/g, "") !== params.dir) throw new Error(`Directory name "${params.dir}" is probably invalid! Expected only lowercase and uppercase letters!`);
+
+	const dirPath = path.join(DIR_ITEM_MACROS, params.dir);
+	fs.mkdirSync(dirPath, {recursive: true});
+
+	const filePath = path.join(
+		dirPath,
+		// FIXME better sluggification of `name`
+		`${params.source}_${params.name.toLowerCase().replace(/ /g, "-")}.js`,
+	);
+
+	if (fs.existsSync(filePath)) throw new Error(`File "${filePath}" already exists!`);
+
+	fs.writeFileSync(filePath, MACRO_TEMPLATE, "utf-8");
+
+	Um.info(`MACRO`, `Created macro file "${filePath}"`);
+}
+
+main();

--- a/test/schema/shared.json
+++ b/test/schema/shared.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "shared.json",
-	"version": "0.2.3",
+	"version": "0.2.4",
 
 	"definitions": {
 		"schema": {
@@ -102,6 +102,8 @@
 						"backpack"
 					]
 				},
+
+				"itemMacro": {"type": "string"},
 
 				"_merge": {
 					"type": "object",


### PR DESCRIPTION
Maintain a set of script files, external to the module's core files,
which are baked into the data files at build time. This allows the
scripts to be easily linted/edited with syntax highlighting, and keeps
the human-editable data files junk-free.

Closes #22