### PR TITLE
feat(effects): explicitly set `true` disabled/transfer values

### DIFF
--- a/module/data/feat/__core.json
+++ b/module/data/feat/__core.json
@@ -5,6 +5,7 @@
 			"source": "PHB",
 			"effects": [
 				{
+					"transfer": true,
 					"changes": [
 						{
 							"key": "flags.midi-qol.DR.non-physical",
@@ -12,12 +13,7 @@
 							"value": "3",
 							"priority": "20"
 						}
-					],
-					"flags": {
-						"dae": {
-							"transfer": true
-						}
-					}
+					]
 				}
 			]
 		},
@@ -26,6 +22,7 @@
 			"source": "PHB",
 			"effects": [
 				{
+					"transfer": true,
 					"changes": [
 						{
 							"key": "flags.midi-qol.advantage.concentration",
@@ -33,12 +30,7 @@
 							"value": "1",
 							"priority": "20"
 						}
-					],
-					"flags": {
-						"dae": {
-							"transfer": true
-						}
-					}
+					]
 				}
 			]
 		}

--- a/module/data/item/__core.json
+++ b/module/data/item/__core.json
@@ -5,6 +5,7 @@
 			"source": "DMG",
 			"effects": [
 				{
+					"transfer": true,
 					"changes": [
 						{
 							"key": "flags.midi-qol.advantage.skill.prc",
@@ -12,12 +13,7 @@
 							"value": "1",
 							"priority": "20"
 						}
-					],
-					"flags": {
-						"dae": {
-							"transfer": true
-						}
-					}
+					]
 				}
 			],
 			"_merge": {

--- a/module/data/subclassFeature/__core.json
+++ b/module/data/subclassFeature/__core.json
@@ -38,6 +38,11 @@
 					],
 					"duration": {
 						"seconds": 60
+					},
+					"flags": {
+						"dae": {
+							"selfTarget": true
+						}
 					}
 				}
 			]

--- a/test/schema/shared.json
+++ b/test/schema/shared.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "shared.json",
-	"version": "0.2.4",
+	"version": "0.3.0",
 
 	"definitions": {
 		"schema": {
@@ -63,7 +63,8 @@
 
 				"duration": {"type": "object"},
 
-				"disabled": {"type": "boolean"}
+				"disabled": {"const": true},
+				"transfer": {"const": true}
 			},
 			"required": ["changes"],
 			"additionalProperties": false

--- a/tool/public/client.js
+++ b/tool/public/client.js
@@ -1,51 +1,93 @@
+"use strict";
 
 class ConverterUi {
-	static init () {
-		const iptFile = document.getElementById("ipt-file");
-		const iptText = document.getElementById("ipt-text");
-		const btnConvert = document.getElementById("btn-convert");
-		const btnCopy = document.getElementById("btn-copy");
-		const outText = document.getElementById("out-text");
+	static _iptFile = null;
+	static _iptText = null;
+	static _btnConvert = null;
+	static _btnCopy = null;
+	static _outText = null;
 
-		iptFile.addEventListener("change", () => {
-			const reader = new FileReader();
-			reader.readAsText(iptFile.files[0]);
-			reader.onload = () => {
-				let text;
+	static _onChange_file () {
+		const reader = new FileReader();
+		reader.readAsText(this._iptFile.files[0]);
 
-				// Check whether filetype is legal
-				if (iptFile.value.match(/\.(json|txt)$/i) || !iptFile.value.includes(".")) { // .json, .txt, or no filetype
-					text = reader.result;
-				} else if (iptFile.value.match(/\.db$/i)) { // .db
-					text = JSON.stringify(reader.result.split("\n").filter(it => it.length).map(it => JSON.parse(it)), null, "\t");
-				} else {
-					outText.value = "Failed to parse input text!\n\n> Invalid filetype";
-					console.error(`Failed to load invalid filetype: .${iptFile.value.split(".").slice(-1)[0]}`);
-					return;
-				}
-
-				iptText.value = text;
-				doConvert();
-			};
-		});
-
-		const doConvert = () => {
-			try {
-				outText.value = JSON.stringify(Converter.getConverted(JSON.parse(iptText.value)), null, "\t");
-			} catch (e) {
-				outText.value = `Failed to parse input text!\n\n${e}`;
-				throw e;
+		const getPreConvertedTextMeta = () => {
+			// Check whether filetype is legal
+			if (this._iptFile.value.match(/\.(json|txt)$/i) || !this._iptFile.value.includes(".")) { // .json, .txt, or no filetype
+				return {text: reader.result, error: null};
 			}
+
+			if (this._iptFile.value.match(/\.db$/i)) { // .db
+				return {
+					text: JSON.stringify(reader.result.split("\n").filter(it => it.length).map(it => JSON.parse(it)), null, "\t"),
+					error: null,
+				};
+			}
+
+			return {
+				text: "Failed to parse input text!\n\n> Invalid filetype",
+				error: `Failed to load invalid filetype: .${this._iptFile.value.split(".").slice(-1)[0]}`,
+			};
 		};
 
-		btnConvert.addEventListener("click", () => doConvert());
+		reader.onload = () => {
+			const {text, error} = getPreConvertedTextMeta();
 
-		btnCopy.addEventListener("click", async () => {
-			await navigator.clipboard.writeText(outText.value);
-			btnCopy.innerHTML = "Copied ✓";
-			console.log("Copied!");
-			window.setTimeout(() => btnCopy.innerHTML = "Copy", 500);
-		});
+			this._iptText.value = text;
+			if (error) {
+				console.error(error);
+				return;
+			}
+
+			this._doConvert();
+		};
+	}
+
+	static async _pOnClick_btnCopy () {
+		await navigator.clipboard.writeText(this._outText.value);
+		this._btnCopy.innerHTML = "Copied ✓";
+		console.log("Copied!");
+		window.setTimeout(() => this._btnCopy.innerHTML = "Copy", 500);
+	}
+
+	static _doConvert () {
+		try {
+			this._doConvert_();
+		} catch (e) {
+			this._outText.value = `Failed to parse input text!\n\n${e}`;
+			throw e;
+		}
+	}
+
+	static _doConvert_ () {
+		this._outText.value = JSON.stringify(Converter.getConverted(JSON.parse(this._iptText.value)), null, "\t");
+	}
+
+	static init () {
+		this._iptFile = document.getElementById("ipt-file");
+		this._iptText = document.getElementById("ipt-text");
+		this._btnConvert = document.getElementById("btn-convert");
+		this._btnCopy = document.getElementById("btn-copy");
+		this._outText = document.getElementById("out-text");
+
+		this._iptFile.addEventListener("change", this._onChange_file.bind(this));
+		this._btnConvert.addEventListener("click", this._doConvert.bind(this));
+		this._btnCopy.addEventListener("click", this._pOnClick_btnCopy.bind(this));
+	}
+}
+
+class ConverterUtil {
+	static copyTruthy (out, obj, {additionalFalsyValues = null} = {}) {
+		Object.entries(obj)
+			.forEach(([k, v]) => {
+				if (additionalFalsyValues && additionalFalsyValues.has(v)) return;
+
+				if (!v) return;
+				if (v instanceof Array && !v.length) return;
+				if (typeof v === "object" && !Object.keys(v).length) return;
+
+				out[k] = v;
+			});
 	}
 }
 
@@ -53,8 +95,8 @@ class Converter {
 	static getConverted (json) {
 		if (json instanceof Array) return json.map(it => this.getConverted(it));
 
-		const effects = this._getEffects(json);
-		const flags = this._getFlags(json);
+		const effects = EffectConverter.getEffects(json);
+		const flags = FlagConverter.getFlags(json);
 
 		return {
 			name: json.name,
@@ -69,112 +111,10 @@ class Converter {
 		if (!sourceRaw) return null;
 		return sourceRaw.split(/[,;.]/g)[0].trim();
 	}
+}
 
-	static _getEffects (json) {
-		if (!json.effects?.length) return;
-
-		return json.effects
-			.map(eff => {
-				// N.b. "selectedKey" is midi-qol UI QoL tracking data, and can be safely skipped
-				["_id", "disabled", "icon", "label", "origin", "transfer", "tint", "selectedKey"].forEach(prop => delete eff[prop]);
-
-				if (!eff.changes?.length) delete eff.changes;
-				else {
-					eff.changes = eff.changes.map(it => ({...it, mode: this._getEffectMode(it.mode)}));
-				}
-
-				if (Object.keys(eff.flags || {}).length) {
-					const flagsNxt = {};
-					Object.entries(eff.flags)
-						.forEach(([k, v]) => {
-							const flagsNxtSub = {};
-							this._copyTruthy(
-								flagsNxtSub,
-								v,
-								{
-									additionalFalsyValues: new Set([
-										// region dae
-										"none",
-										// endregion
-
-										// region ActiveAuras
-										"None",
-										// endregion
-
-										// region dnd5e-helpers
-										"Ignore",
-										// endregion
-									]),
-								},
-							);
-
-							if (Object.keys(flagsNxtSub).length) flagsNxt[k] = flagsNxtSub;
-						});
-					eff.flags = flagsNxt;
-				}
-
-				if (eff.duration) {
-					const durationNxt = {};
-					this._copyTruthy(durationNxt, eff.duration);
-					if (Object.keys(durationNxt).length) eff.duration = durationNxt;
-					else delete eff.duration;
-				}
-
-				if (!eff.changes?.length && !Object.keys(eff.flags || {}).length) return null;
-
-				// region Module requirements
-				const requires = {};
-
-				(eff.changes || [])
-					.forEach(it => {
-						const [ptFlags, ptModule] = (it.key || "").split(".").slice(0, 2);
-						if (ptFlags !== "flags") return;
-						const moduleId = this._getModuleId(ptModule);
-						if (!moduleId) return;
-						requires[moduleId] = true;
-					});
-
-				Object.keys(eff.flags || {})
-					.forEach(k => {
-						const moduleId = this._getModuleId(k);
-						if (!moduleId) return;
-						requires[moduleId] = true;
-					});
-
-				if (Object.keys(requires).length) eff.requires = requires;
-				// endregion
-
-				return eff;
-			})
-			.filter(Boolean);
-	}
-
-	static _getModuleId (flagKey) {
-		switch (flagKey) {
-			// If the key matches the module's ID
-			case "ActiveAuras":
-			case "dae":
-			case "dnd5e-helpers":
-			case "midi-qol":
-				return flagKey;
-
-			default: return null;
-		}
-	}
-
-	static _getEffectMode (modeRaw) {
-		switch (modeRaw) {
-			case 0: return "CUSTOM";
-			case 1: return "MULTIPLY";
-			case 2: return "ADD";
-			case 3: return "DOWNGRADE";
-			case 4: return "UPGRADE";
-			case 5: return "OVERRIDE";
-			default: return modeRaw;
-		}
-	}
-
-	static _getFlags (json) {
+class FlagConverter {
+	static getFlags (json) {
 		if (!Object.keys(json.flags || {}).length) return;
 
 		const out = {};
@@ -191,19 +131,19 @@ class Converter {
 					// region Handle these
 					case "midi-qol": {
 						const outSub = {};
-						this._copyTruthy(outSub, flags);
+						ConverterUtil.copyTruthy(outSub, flags);
 						if (Object.keys(outSub).length) out[k] = outSub;
 						break;
 					}
 					case "midiProperties": {
 						const outSub = {};
-						this._copyTruthy(outSub, flags);
+						ConverterUtil.copyTruthy(outSub, flags);
 						if (Object.keys(outSub).length) out[k] = outSub;
 						break;
 					}
 					case "enhanced-terrain-layer": {
 						const outSub = {};
-						this._copyTruthy(outSub, flags);
+						ConverterUtil.copyTruthy(outSub, flags);
 						if (Object.keys(outSub).length) out[k] = outSub;
 						break;
 					}
@@ -218,18 +158,126 @@ class Converter {
 
 		if (Object.keys(out).length) return out;
 	}
+}
 
-	static _copyTruthy (out, obj, {additionalFalsyValues = null} = {}) {
-		Object.entries(obj)
-			.forEach(([k2, v2]) => {
-				if (additionalFalsyValues && additionalFalsyValues.has(v2)) return;
+class EffectConverter {
+	static getEffects (json) {
+		if (!json.effects?.length) return;
 
-				if (!v2) return;
-				if (v2 instanceof Array && !v2.length) return;
-				if (typeof v2 === "object" && !Object.keys(v2).length) return;
+		return json.effects
+			.map(eff => this._getEffect(eff))
+			.filter(Boolean);
+	}
 
-				out[k2] = v2;
+	static _getEffect (eff) {
+		this._mutPreClean(eff);
+
+		this._mutChanges(eff);
+
+		this._mutFlags(eff);
+		this._mutDuration(eff);
+
+		if (!eff.changes?.length && !Object.keys(eff.flags || {}).length) return null;
+
+		this._mutRequires(eff);
+
+		return eff;
+	}
+
+	static _mutPreClean (eff) {
+		// N.b. "selectedKey" is midi-qol UI QoL tracking data, and can be safely skipped
+		["_id", "icon", "label", "origin", "tint", "selectedKey", "disabled", "transfer"].forEach(prop => delete eff[prop]);
+	}
+
+	static _mutChanges (eff) {
+		if (!eff.changes?.length) return delete eff.changes;
+
+		eff.changes = eff.changes.map(it => ({...it, mode: this._getChangeMode(it.mode)}));
+	}
+
+	static _FLAGS_FALSY_VALUES = new Set([
+		// region dae
+		"none",
+		// endregion
+
+		// region ActiveAuras
+		"None",
+		// endregion
+
+		// region dnd5e-helpers
+		"Ignore",
+		// endregion
+	]);
+
+	static _mutFlags (eff) {
+		if (!Object.keys(eff.flags || {}).length) return delete eff.flags;
+
+		const flagsNxt = {};
+		Object.entries(eff.flags)
+			.forEach(([namespace, moduleFlags]) => {
+				const moduleFlagsNxt = {};
+				ConverterUtil.copyTruthy(moduleFlagsNxt, moduleFlags, {additionalFalsyValues: this._FLAGS_FALSY_VALUES});
+				if (Object.keys(moduleFlagsNxt).length) flagsNxt[namespace] = moduleFlagsNxt;
 			});
+
+		if (Object.keys(flagsNxt).length) eff.flags = flagsNxt;
+		else delete eff.flags;
+	}
+
+	static _mutDuration (eff) {
+		if (!eff.duration) return;
+
+		const durationNxt = {};
+		ConverterUtil.copyTruthy(durationNxt, eff.duration);
+		if (Object.keys(durationNxt).length) eff.duration = durationNxt;
+		else delete eff.duration;
+	}
+
+	static _mutRequires (eff) {
+		const requires = {};
+
+		(eff.changes || [])
+			.forEach(it => {
+				const [ptFlags, ptModule] = (it.key || "").split(".").slice(0, 2);
+				if (ptFlags !== "flags") return;
+				const moduleId = this._getRequiresModuleId(ptModule);
+				if (!moduleId) return;
+				requires[moduleId] = true;
+			});
+
+		Object.keys(eff.flags || {})
+			.forEach(k => {
+				const moduleId = this._getRequiresModuleId(k);
+				if (!moduleId) return;
+				requires[moduleId] = true;
+			});
+
+		if (Object.keys(requires).length) eff.requires = requires;
+	}
+
+	static _getRequiresModuleId (flagKey) {
+		switch (flagKey) {
+			// If the key matches the module's ID
+			case "ActiveAuras":
+			case "dae":
+			case "dnd5e-helpers":
+			case "midi-qol":
+				return flagKey;
+
+			default: return null;
+		}
+	}
+
+	static _getChangeMode (modeRaw) {
+		switch (modeRaw) {
+			case 0: return "CUSTOM";
+			case 1: return "MULTIPLY";
+			case 2: return "ADD";
+			case 3: return "DOWNGRADE";
+			case 4: return "UPGRADE";
+			case 5: return "OVERRIDE";
+			default: return modeRaw;
+		}
 	}
 }
 

--- a/tool/public/client.js
+++ b/tool/public/client.js
@@ -125,6 +125,7 @@ class FlagConverter {
 					// region Discard these
 					case "srd5e":
 					case "core":
+					case "favtab": // https://github.com/syl3r86/favtab
 						break;
 						// endregion
 


### PR DESCRIPTION
Plutonium's AE handling, when it comes to compatibility with
MidiQOL/DAE, is currently abysmal. As part of efforts to straighten that
out moving forward, be more explicit about which effects have which
`transfer`/`disabled` values.

Additionally, avoid using MidiQOl-specific versions of these flags, as
they don't seem to take precedence over the real `transfer`/`disabled`,
which Plutonium always sets to a non-null value internally.

Note that for all "addon" effects, the implicit default for both values
is `false`. This also applies to the `foundry-*.json`s/etc. in the
5etools source, so copy-pasting between the two won't require any
changes.