### PR TITLE
Avoid using version'd manifest URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "plutonium-addon-automation",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "plutonium-addon-automation",
-			"version": "0.1.6",
+			"version": "0.1.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@league-of-foundry-developers/foundry-vtt-types": "^9.269.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "plutonium-addon-automation",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"author": "Giddy",
 	"type": "module",
 	"license": "MIT",

--- a/script/build-task.js
+++ b/script/build-task.js
@@ -35,7 +35,9 @@ export const buildTask = async () => {
 		],
 		readme: "README.md",
 		license: "MIT",
-		manifest: `https://github.com/TheGiddyLimit/plutonium-addon-automation/releases/download/${packageJson.version}/module.json`,
+		// Use "latest" as manifest URL, so that when updating the module the user always gets the latest version
+		manifest: `https://github.com/TheGiddyLimit/plutonium-addon-automation/releases/latest/download/module.json`,
+		// Set "download" to this specific version, so that users manually entering the link will receive the version they expect
 		download: `https://github.com/TheGiddyLimit/plutonium-addon-automation/releases/download/${packageJson.version}/plutonium-addon-automation.zip`,
 		minimumCoreVersion: "9",
 		compatibleCoreVersion: "9",


### PR DESCRIPTION
Locking the "manifest" URL to a specific version prevents the user from
ever updating the module via the "Update" button in Foundry, which is
not ideal.