### PR TITLE
add(spell): Implement Aid

### DIFF
--- a/macro-item/spell/PHB_aid.js
+++ b/macro-item/spell/PHB_aid.js
@@ -1,0 +1,12 @@
+async function macro (args) {
+	const tactor = (await fromUuid(args[1].tokenUuid)).actor;
+
+	const health = tactor.system.attributes.hp.value;
+	const healthChange = eval(args[1].efData.changes[0].value); // eslint-disable-line no-eval
+
+	if (args[0] === "on") {
+		tactor.update({ "system.attributes.hp.value": health + healthChange });
+	} else if (args[0] === "off") {
+		tactor.update({ "system.attributes.hp.value": Math.max(health - healthChange, 0) });
+	}
+}

--- a/module/data/spell/__core.json
+++ b/module/data/spell/__core.json
@@ -1,6 +1,35 @@
 {
 	"spell": [
 		{
+			"name": "Aid",
+			"source": "PHB",
+			"data": {
+				"damage.parts": []
+			},
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "system.attributes.hp.max",
+							"mode": "ADD",
+							"value": "(@item.level - 1) * 5",
+							"priority": 20
+						},
+						{
+							"key": "macro.itemMacro",
+							"mode": "CUSTOM",
+							"value": "",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"seconds": 28800
+					}
+				}
+			],
+			"itemMacro": "PHB_aid.js"
+		},
+		{
 			"name": "Aura of Purity",
 			"source": "PHB",
 			"effects": [


### PR DESCRIPTION
Aid has some controversial behavior, the [top answer](https://rpg.stackexchange.com/a/45345) on RPG Exchange judges that Aid's HP _goes away_ when the spell ends. Also, this HP does not count as healing or temporary HP. Aid's HP pops into existence when the spell is cast, and disappears when the spell ends.

This implementation tries to reflect that interpretation. The maximum HP change is done as a system AE, and the item macro does as little work as possible to increment, and subsequently decrement, the current HP value as described above.

Tested/Working/Linted/etc