### PR TITLE
feat(spell): Implement Chill Touch

### DIFF
--- a/module/data/spell/__core.json
+++ b/module/data/spell/__core.json
@@ -233,6 +233,53 @@
 			]
 		},
 		{
+			"name": "Chill Touch",
+			"source": "PHB",
+			"system": {
+				"duration.units": null,
+				"duration.value": null
+			},
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.disadvantage.attack.all",
+							"mode": "CUSTOM",
+							"value": "targetId === \"@token\" && details.type.value === \"undead\"",
+							"priority": 20
+						}
+					],
+					"flags": {
+						"dae": {
+							"specialDuration": [
+								"turnEndSource"
+							]
+						}
+					}
+				},
+				{
+					"changes": [
+						{
+							"key": "system.traits.di.value",
+							"mode": "CUSTOM",
+							"value": "healing",
+							"priority": 20
+						}
+					],
+					"flags": {
+						"core": {
+							"statusId": "Chill Touch"
+						},
+						"dae": {
+							"specialDuration": [
+								"turnStartSource"
+							]
+						}
+					}
+				}
+			]
+		},
+		{
 			"name": "Darkvision",
 			"source": "PHB",
 			"effects": [


### PR DESCRIPTION
Implement Chill Touch using the same mechanism that midi does, with some cosmetic changes.

Chill Touch is two AEs, one to handle the healing immunity and another to grant attack disadvantage for undead mobs attacking the source token. Both AEs are always applied, the attack disadvantage is gated behind an activation condition.

Because there are two AEs, we have a choice to make with regards to displaying a status icon on the token. Midi sets a false duration on both, displaying the same icon twice. In this PR we set a `statusId` on only the healing immunity, which will cause it to display a status icon. The attack disadvantage is a "passive" AE and while it will persist to the end of the source turn, it will not display status icon.

There could be an argument made for attaching the icon to the disadvantage AE, but I think it's a bikeshed.