### PR TITLE
feat(build): prefer releasing on tag to releasing on merge to master

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,8 @@ name: Build and Deploy
 
 on:
    push:
-      branches:
-         - master
+      tags:
+         - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
    build-and-deploy:


### PR DESCRIPTION
The former was set up in order to avoid having release branches, but produces more problems than it solves if multiple people are contributing to the repository. Instead, only build on tagged release versions, whatever branch they happen to be in.

In order to ensure random PRs don't trigger releases, tag protection has now been added to the repo, allowing only admins/maintainers to push version tags.