### PR TITLE
feat(spell): Implement Arms of Hadar

### DIFF
--- a/module/data/spell/__core.json
+++ b/module/data/spell/__core.json
@@ -69,6 +69,25 @@
 			]
 		},
 		{
+			"name": "Arms of Hadar",
+			"source": "PHB",
+			"system": {
+				"duration.units": null,
+				"target.type": "creature",
+				"range.units": "spec"
+			},
+			"flags": {
+				"midiProperties": {
+					"halfdam": true
+				}
+			},
+			"effects": [
+				{
+					"convenientEffect": "Reaction"
+				}
+			]
+		},
+		{
 			"name": "Aura of Purity",
 			"source": "PHB",
 			"effects": [


### PR DESCRIPTION
[The Arms. The Arms of Hadar. The Arms chosen specially for Hadar. Hadar's Arms.](https://youtu.be/NcKGw-IO5Uc)

System data is obvious, sets up duration, range, units, and flags in a way that midi understands to do its business.

The effects prop is my preferred way to handle abilities that apply status effects, just throw that bad boy right into the effects array, whole thing. We might want a way to shorthand this that the DataConverter understands and can unpack instead of this approach, perhaps even invoking Dfred's API to get the correct effect data instead of hard coding it into abilities ourselves.

But for now, this works.