### PR TITLE
feat(spell): Implement Aura of Vitality

### DIFF
--- a/macro-item/spell/PHB_aura-of-vitality.js
+++ b/macro-item/spell/PHB_aura-of-vitality.js
@@ -1,0 +1,49 @@
+async function macro (args) {
+	const token = (await fromUuid(args[1].tokenUuid));
+
+	const base = args[1].efData.flags.dae.itemData;
+	const system = mergeObject(
+		base.system,
+		{
+			activation: {
+				cost: 1,
+				type: "bonus",
+			},
+			components: {
+				concentration: false,
+				vocal: true,
+			},
+			damage: { parts: [["2d6", "healing"]] },
+			duration: { units: "inst" },
+			preparation: {
+				mode: "atwill",
+				prepared: true,
+			},
+			range: {
+				units: "ft",
+				value: 30,
+			},
+			target: {
+				type: "creature",
+				value: 1,
+			},
+		},
+		{ overwrite: true },
+	);
+
+	if (args[0] === "on") {
+		await warpgate.mutate(token, {
+			embedded: {
+				Item: {
+					"Invoke Vitality": {
+						type: "spell",
+						img: base.img,
+						system: system,
+					},
+				},
+			},
+		});
+	} else if (args[0] === "off") {
+		await warpgate.revert(token);
+	}
+}

--- a/module/data/spell/__core.json
+++ b/module/data/spell/__core.json
@@ -67,6 +67,33 @@
 			]
 		},
 		{
+			"name": "Aura of Vitality",
+			"source": "PHB",
+			"system": {
+				"damage.parts": [],
+				"target.type": "self"
+			},
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "macro.itemMacro",
+							"mode": "CUSTOM",
+							"value": "",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"seconds": 60
+					},
+					"requires": {
+						"warpgate": true
+					}
+				}
+			],
+			"itemMacro": "PHB_aura-of-vitality.js"
+		},
+		{
 			"name": "Bane",
 			"source": "PHB",
 			"effects": [


### PR DESCRIPTION
Continuing my alphabetical march through the PHB A-spells

Aura of Vitality, despite the name, is not an aura. It's an item summoner. It summons an unnamed item that gives the user the ability to cast a bonus-action 2d6 healing spell within a 30 ft radius for the next 60 seconds.

We fudge this a little bit. We use warpgate to create a a temporary item (cloned from the base Aura of Vitality item, with necessary fields updated appropriately), but we give it a name, "Invoke Vitality". This appears as an At-Will spell on the user's sheet, and sticks around as long as the "Aura" lasts.

The other thing we fudge is range. I set the range of "Invoke Vitality" to 30ft, for simplicity. I think RAW this should be 27.5ft, because technically the 30 ft radius starts at the center of the 5 sqft grid cell, but ranges are measured from the edge of the grid cell. As a practical matter, I believe these always work out to cover the same number of cells and seeing "27.5 ft" will surely confuse our more simple-minded players.