### PR TITLE
fix(spell): Use named mutations for warpgate

### DIFF
--- a/macro-item/spell/PHB_aura-of-vitality.js
+++ b/macro-item/spell/PHB_aura-of-vitality.js
@@ -32,18 +32,22 @@ async function macro (args) {
 	);
 
 	if (args[0] === "on") {
-		await warpgate.mutate(token, {
-			embedded: {
-				Item: {
-					"Invoke Vitality": {
-						type: "spell",
-						img: base.img,
-						system: system,
+		await warpgate.mutate(token,
+			{
+				embedded: {
+					Item: {
+						"Invoke Vitality": {
+							type: "spell",
+							img: base.img,
+							system: system,
+						},
 					},
 				},
 			},
-		});
+			{},
+			{ name: "plutonium-addon-automation-aura-of-vitality" },
+		);
 	} else if (args[0] === "off") {
-		await warpgate.revert(token);
+		await warpgate.revert(token, "plutonium-addon-automation-aura-of-vitality");
 	}
 }


### PR DESCRIPTION
We shouldn't rely on push/popping the mutation stack.

Thanks to the new [warpgate docs](https://trioderegion.github.io/warpgate/index.html) I learned how to do this correctly and actually attach a name to the mutation that we can use to identify applied mutations.