### PR TITLE
Aadd dependency settings check/config dialogue

### DIFF
--- a/module/js/Main.js
+++ b/module/js/Main.js
@@ -6,25 +6,9 @@ class Util {
 		`color: #5494cc; font-weight: bold;`,
 		`|`,
 	];
-
-	static get plutoniumApi () {
-		return game.modules.get(SharedConsts.MODULE_NAME_PARENT)?.api
-			|| game.modules.get(SharedConsts.MODULE_NAME_PARENT_ALT)?.api;
-	}
 }
 
 class DataManager {
-	static _P_LOADING_INDEX = null;
-	static _INDEX = null;
-
-	static async _pLoadIndex () {
-		this._P_LOADING_INDEX = this._P_LOADING_INDEX || (async () => {
-			this._INDEX = await DataUtil.loadJSON(`${SharedConsts.MODULE_PATH}/data/_generated/index.json`);
-		})();
-
-		await this._P_LOADING_INDEX;
-	}
-
 	static async api_pGetExpandedAddonData (
 		{
 			propJson,
@@ -32,12 +16,12 @@ class DataManager {
 			fnMatch,
 		},
 	) {
-		await this._pLoadIndex();
+		const index = await (this._P_INDEX = this._P_INDEX || DataUtil.loadJSON(`${SharedConsts.MODULE_PATH}/data/_generated/index.json`));
 
-		const ixFile = MiscUtil.get(this._INDEX, propJson, ...path);
+		const ixFile = MiscUtil.get(index, propJson, ...path);
 		if (ixFile == null) return null;
 
-		const json = await DataUtil.loadJSON(`${SharedConsts.MODULE_PATH}/data/${this._INDEX._file[ixFile]}`);
+		const json = await DataUtil.loadJSON(`${SharedConsts.MODULE_PATH}/data/${index._file[ixFile]}`);
 
 		const out = (json?.[propJson] || [])
 			.find(it => fnMatch(it));
@@ -111,19 +95,259 @@ class DataManager {
 	}
 }
 
+class SettingsManager {
+	static _SETTING_METAS = [
+		{
+			moduleId: "dfreds-convenient-effects",
+			settingKey: "modifyStatusEffects",
+			isGmOnly: true,
+			expectedValue: "replace",
+			allowedValues: ["replace", "add"],
+		},
+		{
+			moduleId: "midi-qol",
+			settingKey: "ConfigSettings",
+			propPath: "autoCEEffects",
+			isGmOnly: true,
+			expectedValue: "cepri",
+			displaySettingName: "midi-qol.AutoCEEffects.Name",
+		},
+		{
+			moduleId: "itemacro",
+			settingKey: "defaultmacro",
+			isGmOnly: true,
+			expectedValue: false,
+		},
+		{
+			moduleId: "itemacro",
+			settingKey: "charsheet",
+			isGmOnly: true,
+			expectedValue: false,
+		},
+		{
+			moduleId: "token-action-hud",
+			settingKey: "itemMacroReplace",
+			expectedValue: "showOriginal",
+		},
+	];
+
+	static _getSettingsData () {
+		return this._SETTING_METAS
+			.map((
+				{
+					moduleId,
+					settingKey,
+					propPath,
+					isGmOnly,
+					expectedValue,
+					allowedValues,
+					displaySettingName,
+				},
+				ixSetting,
+			) => {
+				allowedValues = allowedValues === undefined ? [expectedValue] : allowedValues;
+
+				if (isGmOnly && !game.user.isGM) return null;
+				if (!game.modules.get(moduleId)?.active) return null;
+
+				const setting = game.settings.settings.get(`${moduleId}.${settingKey}`);
+				if (!setting) return null;
+
+				let value = game.settings.get(moduleId, settingKey);
+				if (propPath) value = foundry.utils.getProperty(value, propPath);
+
+				return {
+					name: `${game.modules.get(moduleId).title} \u2013 <i>${game.i18n.localize(displaySettingName || setting.name)}</i>`,
+					isExpected: expectedValue === value,
+					isAllowed: allowedValues.includes(value),
+					displayExpectedValue: setting.choices
+						? game.i18n.localize(setting.choices[expectedValue] || expectedValue)
+						: expectedValue,
+					ixSetting,
+				};
+			})
+			.filter(Boolean);
+	}
+
+	/* -------------------------------------------- */
+
+	static _MenuSettingsPrompt = class extends FormApplication {
+		static get defaultOptions () {
+			return foundry.utils.mergeObject(super.defaultOptions, {
+				template: `${SharedConsts.MODULE_PATH}/template/MenuSettingsPrompt.hbs`,
+			});
+		}
+
+		get title () {
+			return `${SharedConsts.MODULE_TITLE} \u2013 ${game.i18n.localize("PLUTAA.Configure Dependencies")}`;
+		}
+
+		#lastData = null;
+
+		async getData (opts) {
+			const settings = SettingsManager._getSettingsData();
+
+			const out = {
+				...(await super.getData(opts)),
+				settings,
+				isMassError: settings.some(it => !it.isExpected),
+				isMassWarning: settings.some(it => !it.isAllowed),
+			};
+
+			this.#lastData = out;
+
+			return out;
+		}
+
+		async _pFixSetting ({ix}) {
+			const {
+				expectedValue,
+				propPath,
+				moduleId,
+				settingKey,
+			} = SettingsManager._SETTING_METAS[ix];
+
+			let value = expectedValue;
+			if (propPath) {
+				value = foundry.utils.getProperty(value, propPath);
+			}
+
+			await game.settings.set(moduleId, settingKey, value);
+		}
+
+		activateListeners ($html) {
+			super.activateListeners($html);
+			$html.find(`[name="btn-fix-all"]`).on("click", this._onClick_pFixAll.bind(this));
+			$html.find(`[name="btn-fix"]`).on("click", this._onClick_pFixSetting.bind(this));
+		}
+
+		async _onClick_pFixAll () {
+			try {
+				const cnt = this.#lastData.settings.filter(it => !it.isExpected).length;
+				for (let ix = 0; ix < this.#lastData.settings.length; ++ix) {
+					const setting = this.#lastData.settings[ix];
+					if (setting.isExpected) continue;
+					await this._pFixSetting({ix});
+					await this.render();
+					game.settings.sheet.render();
+				}
+				ui.notifications.info(`${cnt} setting${cnt === 1 ? "" : "s"} updated!`);
+				await this.close({force: true});
+			} catch (e) {
+				console.log(e);
+				ui.notifications.error(`Failed to update setting! ${VeCt.STR_SEE_CONSOLE}`);
+			}
+		}
+
+		async _onClick_pFixSetting (evt) {
+			const ix = Number(evt.currentTarget.getAttribute("data-setting-ix"));
+
+			try {
+				await this._pFixSetting({ix});
+				ui.notifications.info("Setting updated!");
+				await this.render();
+				game.settings.sheet.render();
+			} catch (e) {
+				console.log(e);
+				ui.notifications.error(`Failed to update setting! ${VeCt.STR_SEE_CONSOLE}`);
+			}
+		}
+
+		_updateObject (evt, formData) { /* No-op */ }
+	};
+
+	/* -------------------------------------------- */
+
+	static handleInit () {
+		game.settings.registerMenu(
+			SharedConsts.MODULE_ID,
+			"menuConfigureDependencies",
+			{
+				name: "PLUTAA.Configure Dependencies",
+				hint: "Check and configure settings for module dependencies.",
+				label: "Configure",
+				icon: "fas fa-fw fa-cogs",
+				type: this._MenuSettingsPrompt,
+				restricted: false,
+			},
+		);
+
+		game.settings.register(
+			SharedConsts.MODULE_ID,
+			"isNotifyOnLoad",
+			{
+				name: "PLUTAA.Show Config on Load",
+				hint: "Display the configuration dialogue on load, if incompatible module settings are detected.",
+				default: true,
+				type: Boolean,
+				scope: "client",
+				config: true,
+				restricted: false,
+			},
+		);
+	}
+
+	/* -------------------------------------------- */
+
+	static handleReady () {
+		this._handleReady_doPostCompatibilityNotification();
+	}
+
+	static _handleReady_doPostCompatibilityNotification () {
+		if (!game.settings.get(SharedConsts.MODULE_ID, "isNotifyOnLoad")) return;
+
+		const settings = SettingsManager._getSettingsData();
+
+		if (settings.every(it => it.isExpected)) return;
+
+		const app = new this._MenuSettingsPrompt();
+		app.render(true);
+	}
+}
+
 class Api {
-	static init () { game.modules.get(SharedConsts.MODULE_ID).api = this; }
+	static handleReady () { game.modules.get(SharedConsts.MODULE_ID).api = this; }
 
 	static pGetExpandedAddonData (opts) { return DataManager.api_pGetExpandedAddonData(opts); }
 }
 
-Hooks.on("ready", () => {
-	console.log(...Util.LGT, `Firing "ready" hook...`);
-	try {
-		Api.init();
-		console.log(...Util.LGT, `Initialisation complete!`);
-	} catch (e) {
-		console.error(...Util.LGT, e);
-		window.alert(`Failed to initialise ${SharedConsts.MODULE_TITLE}! ${VeCt.STR_SEE_CONSOLE}`);
+class Main {
+	static _HAS_FAILED = false;
+
+	static handleInit () {
+		if (this._HAS_FAILED) return;
+		try {
+			this._handleInit();
+		} catch (e) {
+			this._onError(e);
+		}
 	}
-});
+
+	static _handleInit () {
+		SettingsManager.handleInit();
+	}
+
+	static handleReady () {
+		if (this._HAS_FAILED) return;
+		try {
+			this._handleReady();
+		} catch (e) {
+			this._onError(e);
+		}
+	}
+
+	static _handleReady () {
+		Api.handleReady();
+		SettingsManager.handleReady();
+		console.log(...Util.LGT, `Initialized.`);
+	}
+
+	static _onError (e) {
+		this._HAS_FAILED = true;
+		setTimeout(() => { throw e; });
+		if (ui.notifications?.error) ui.notifications.error(`Failed to initialize ${SharedConsts.MODULE_TITLE}! ${VeCt.STR_SEE_CONSOLE}`);
+	}
+}
+
+Hooks.on("init", Main.handleInit.bind(Main));
+Hooks.on("ready", Main.handleReady.bind(Main));

--- a/module/lang/en.json
+++ b/module/lang/en.json
@@ -1,0 +1,4 @@
+{
+	"PLUTAA.Configure Dependencies": "Configure Dependencies",
+	"PLUTAA.Show Config on Load": "Show Config on Load"
+}

--- a/module/shared/SharedConsts.js
+++ b/module/shared/SharedConsts.js
@@ -5,9 +5,6 @@ class SharedConsts {
 	static MODULE_DIR = `./dist/${SharedConsts.MODULE_ID}`;
 
 	static MODULE_PATH = `modules/${SharedConsts.MODULE_ID}`;
-
-	static MODULE_NAME_PARENT = `plutonium`;
-	static MODULE_NAME_PARENT_ALT = `srd5e`;
 }
 
 export {SharedConsts};

--- a/module/template/MenuSettingsPrompt.hbs
+++ b/module/template/MenuSettingsPrompt.hbs
@@ -1,0 +1,36 @@
+<form class="ve-flex-col ve-window min-h-0 h-100 relative">
+	<div class="py-1 ve-flex-v-center">
+		<button
+			type="button"
+			class="btn btn-default btn-xs ml-auto"
+			name="btn-fix-all"
+			title="{{#if isMassError}}Incompatible setting value(s) detected! Click to fix.{{else if isMassWarning}}Sub-optimal setting value(s) detected. Click to fix.{{else}}Compatible setting values detected.{{/if}}"
+			{{disabled (not (or isMassError isMassWarning))}}
+		>
+			<i class="fas fa-fw {{#if isMassError}}fa-octagon-exclamation{{else if isMassWarning}}fa-triangle-exclamation{{else}}fa-check{{/if}} mr-0"></i>
+		</button>
+	</div>
+
+	<hr class="hr-1">
+
+	{{#each settings as |setting ix|}}
+		<div class="ve-flex-v-center py-1 w-100">
+			<div class="ve-flex w-100 mr-2">{{{name}}}</div>
+			<div  class="ve-flex-v-center no-shrink">
+				{{#if isExpected}}
+					<button type="button" class="btn btn-default btn-xs" name="btn-fix" disabled>
+						<i class="fas fa-fw fa-check mr-0" title="Compatible setting value detected."></i>
+					</button>
+				{{else if isAllowed}}
+					<button type="button" class="btn btn-default btn-xs" name="btn-fix" data-setting-ix="{{ixSetting}}" title="Sub-optimal setting value detected. Click to fix (setting will be set to &quot;{{displayExpectedValue}}&quot;).">
+						<i class="fas fa-fw fa-triangle-exclamation mr-0"></i>
+					</button>
+				{{else}}
+					<button type="button" class="btn btn-default btn-xs" name="btn-fix" data-setting-ix="{{ixSetting}}" title="Incompatible setting value detected! Click to fix (setting will be set to&quot;{{displayExpectedValue}}&quot;).">
+						<i class="fas fa-fw fa-octagon-exclamation mr-0"></i>
+					</button>
+				{{/if}}
+			</div>
+		</div>
+	{{/each}}
+</form>

--- a/script/build-task.js
+++ b/script/build-task.js
@@ -45,6 +45,13 @@ export const buildTask = async () => {
 		},
 		url: "https://www.patreon.com/Giddy5e",
 		bugs: "https://discord.gg/nGvRCDs",
+		languages: [
+			{
+				lang: "en",
+				name: "English",
+				path: "lang/en.json",
+			},
+		],
 
 		relationships: {
 			requires: [


### PR DESCRIPTION
This shows which settings, in other modules, the user has set to incompatible values, and provides them with a quick-fix button.

In addition, the same dialogue is shown on game load, if incompatible settings are detected (and the user has not disabled the notification).

Closes #17