### PR TITLE
Add items from the MidiQOL "Sample Items" compendium

### DIFF
--- a/macro-item/item/DMG_goggles-of-night.js
+++ b/macro-item/item/DMG_goggles-of-night.js
@@ -1,0 +1,24 @@
+/** From "MidiQOL Sample Items" compendium */
+async function macro (args) {
+	const lastArgs = args[args.length - 1];
+	const token = await fromUuid(lastArgs.tokenUuid);
+	if (args[0] === "on") {
+		const updates = {};
+		updates["flags.midi-qol.gogglesSave"] = {
+			"sight.visionMode": token._source.sight.visionMode,
+			"sight.range": token._source.sight.range,
+			"detectionModes": token._source.detectionModes,
+		};
+		let newRange = 60;
+		if (token.sight.visionMode === "darkvision") newRange += 60;
+		updates["sight.visionMode"] = "lightAmplification";
+		updates["sight.range"] = newRange;
+		const detectionModes = token.detectionModes;
+		detectionModes.push({id: "lightAmplification", enabled: true, range: newRange});
+		return token.update(updates);
+	} else if (args[0] === "off") {
+		const updates = token.flags["midi-qol"].gogglesSave;
+		updates["flags.midi-qol.-=gogglesSave"] = null;
+		return token.update(updates);
+	}
+}

--- a/macro-item/item/DMG_lantern-of-revealing.js
+++ b/macro-item/item/DMG_lantern-of-revealing.js
@@ -1,0 +1,34 @@
+/** From "MidiQOL Sample Items" compendium */
+async function macro (args) {
+	const lastArgs = args[args.length - 1];
+	const token = await fromUuid(lastArgs.tokenUuid);
+
+	if (args[0] === "on") {
+		const updates = {};
+		updates["flags.midi-qol.revealingSave"] = {
+			"light.angle": token._source.light.angle,
+			"light.bright": token._source.light.bright,
+			"light.dim": token._source.light.dim,
+			"light.animation": token._source.light.animation,
+			"light.alpha": token._source.light.alpha,
+			"light.contrast": token._source.light.contrast,
+			"light.color": token._source.light.color,
+			"detectionModes": token._source.detectionModes,
+		};
+		updates["light.angle"] = 360;
+		updates["light.bright"] = 30;
+		updates["light.dim"] = 60;
+		updates["light.alpha"] = 0.1;
+		updates["light.contrast"] = 0.5;
+		updates["light.color"] = "#f8c377";
+		const detectionModes = token.detectionModes;
+		detectionModes.push({id: "seeInvisibility", enabled: true, range: 30});
+		updates["detectionModes"] = detectionModes;
+		return token.update(updates);
+	} else if (args[0] === "off") {
+		const updates = token.flags["midi-qol"].revealingSave;
+		updates["flags.midi-qol.-=revealingSave"] = null;
+		console.error("Updates ", updates);
+		return token.update(updates);
+	}
+}

--- a/macro-item/item/DMG_mace-of-disruption.js
+++ b/macro-item/item/DMG_mace-of-disruption.js
@@ -1,0 +1,14 @@
+/** From "MidiQOL Sample Items" compendium */
+async function macro (args) {
+	const version = "10.0.10";
+	try {
+		for (let damageItem of this.damageList) {
+			if (damageItem.newHP <= 25 && args[0].failedSaveUuids.includes(damageItem.tokenUuid)) {
+				damageItem.hpDamage += damageItem.newHP;
+				damageItem.newHP = 0;
+			}
+		}
+	} catch (err) {
+		console.error(`${args[0].itemData.name} - Devil's Glaive ${version}`, err);
+	}
+}

--- a/macro-item/item/DMG_sword-of-life-stealing.js
+++ b/macro-item/item/DMG_sword-of-life-stealing.js
@@ -1,0 +1,12 @@
+/** From "MidiQOL Sample Items" compendium */
+async function macro (args) {
+	const version = "10.0.10";
+	try {
+		if (args[0].diceRoll === 20 && args[0].itemData.system.attunement !== 1 && args[0].otherDamageTotal > (actor.system.attributes.hp.temp ?? 0)) {
+			ChatMessage.create({content: `${args[0].item.name} steals ${args[0].otherDamageTotal} HP`});
+			await actor.update({"system.attributes.hp.temp": args[0].otherDamageTotal});
+		}
+	} catch (err) {
+		console.error(`${args[0].itemData.name} - Sword of Life Stealing ${version}`, err);
+	}
+}

--- a/macro-item/item/DMG_sword-of-sharpness.js
+++ b/macro-item/item/DMG_sword-of-sharpness.js
@@ -1,0 +1,15 @@
+/** From "MidiQOL Sample Items" compendium */
+async function macro (args) {
+	const version = "10.0.10";
+	try {
+		if (args[0].diceRoll === 20 && args[0].itemData.system.attunement !== 1) {
+			const d20 = await (new Roll("1d20")).roll().total;
+			if (d20 === 20) {
+				ChatMessage.create({content: "Sword of Sharpness severed a limb"});
+			}
+		}
+	} catch (err) {
+		console.error(`${args[0].itemData.name} - Sword of Sharpness ${version}`, err);
+		return {};
+	}
+}

--- a/macro-item/item/DMG_sword-of-wounding.js
+++ b/macro-item/item/DMG_sword-of-wounding.js
@@ -1,0 +1,49 @@
+/** From "MidiQOL Sample Items" compendium */
+async function macro (args) {
+	const version = "10.0.10";
+	try {
+		const lastArg = args[args.length - 1];
+		let ttoken = await fromUuid(lastArg.tokenUuid);
+		const tactor = ttoken?.actor;
+		const item = await fromUuid(lastArg.origin);
+		if (args[0] === "on") {
+			const sourceActor = item.parent;
+			const combatTime = game.combat ? (game.combat.round + game.combat.turn / 100) : 0;
+			const lastTime = getProperty(sourceActor.flags, "midi-qol.woundedTime");
+			lastArg.canWound = !game.combat || (combatTime !== lastTime);
+			if (game.combat && lastArg.canWound) {
+				let combatTime = game.combat.round + game.combat.turn / 100;
+				let lastTime = getProperty(sourceActor.flags, "midi-qol.woundedTime");
+				if (combatTime !== lastTime) {
+					setProperty(sourceActor.flags, "midi-qol.woundedTime", combatTime);
+				}
+			}
+			if (!lastArg.canWound) {
+				const stacks = getProperty(lastArg.efData, "flags.dae.stacks") || 1;
+				const label = `${lastArg.efData.label.replace(/\s+\(\d*\)/, "")} (${stacks - 1})`;
+				Hooks.once("midi-qol.RollComplete", () => {
+					tactor.updateEmbeddedDocuments("ActiveEffect", [{ _id: lastArg.efData._id, "flags.dae.stacks": stacks - 1, "label": label }]);
+				});
+			}
+		} else if (args[0] === "each") {
+			const woundCount = getProperty(lastArg.efData, "flags.dae.stacks");
+			if (!woundCount) return;
+			const saveType = "con";
+			const DC = 15;
+			const flavor = `${CONFIG.DND5E.abilities[saveType]} DC${DC} ${item?.name || ""}`;
+			let save = (await tactor.rollAbilitySave(saveType, { flavor, fastForward: true })).total;
+			if (save >= DC) {
+				const effectsToDelete = tactor.effects.filter(ef => ef.origin === lastArg.origin).map(ef => ef.id);
+				ChatMessage.create({content: "Save was made"});
+				await MidiQOL.socket().executeAsGM("removeEffects", { actorUuid: tactor.uuid, effects: [...effectsToDelete, lastArg.effectId] });
+			} else {
+				let damageRoll = await new Roll(`${woundCount}d4[necrotic]`).roll({async: true}); // could be argument
+				const wf = new MidiQOL.DamageOnlyWorkflow(tactor, ttoken, damageRoll.total, "necrotic", [ttoken], damageRoll, { flavor: `Failed Save for ${item.name}`, itemData: item?.toObject(false), itemCardId: "new", useOther: true });
+			}
+		} else if (args[0] === "off") {
+			// do any clean up
+		}
+	} catch (err) {
+		console.error(`Sword of Wounding ${version}`, err);
+	}
+}

--- a/macro-item/item/PHB_bullseye-lantern.js
+++ b/macro-item/item/PHB_bullseye-lantern.js
@@ -1,0 +1,30 @@
+/** From "MidiQOL Sample Items" compendium */
+async function macro (args) {
+	const lastArgs = args[args.length - 1];
+	const token = await fromUuid(lastArgs.tokenUuid);
+
+	if (args[0] === "on") {
+		const updates = {};
+		updates["flags.midi-qol.bullseyeSave"] = {
+			"light.angle": token._source.light.angle,
+			"light.bright": token._source.light.bright,
+			"light.dim": token._source.light.dim,
+			"light.animation": token._source.light.animation,
+			"light.alpha": token._source.light.alpha,
+			"light.contrast": token._source.light.contrast,
+			"light.color": token._source.light.color,
+		};
+		updates["light.angle"] = 60;
+		updates["light.bright"] = 60;
+		updates["light.dim"] = 120;
+		updates["light.alpha"] = 0.1;
+		updates["light.contrast"] = 0.5;
+		updates["light.color"] = "#f8c377";
+		return token.update(updates);
+	} else if (args[0] === "off") {
+		const updates = token.flags["midi-qol"].bullseyeSave;
+		updates["flags.midi-qol.-=bullseyeSave"] = null;
+		console.error("Updates ", updates);
+		return token.update(updates);
+	}
+}

--- a/macro-item/spell/XGE_toll-the-dead.js
+++ b/macro-item/spell/XGE_toll-the-dead.js
@@ -1,5 +1,5 @@
+/** From "MidiQOL Sample Items" compendium */
 async function macro (args) {
-	// From "MidiQOL Sample Items" compendium
 	if (args[0].macroPass !== "preDamageRoll") return;
 
 	const target = await fromUuid(args[0].targetUuids[0]);

--- a/module/data/item/__core.json
+++ b/module/data/item/__core.json
@@ -1,6 +1,138 @@
 {
 	"item": [
 		{
+			"name": "Bullseye Lantern",
+			"source": "PHB",
+			"effects": [
+				{
+					"duration": {
+						"seconds": 21600
+					},
+					"changes": [
+						{
+							"key": "macro.itemMacro",
+							"mode": "ADD",
+							"value": ""
+						}
+					]
+				}
+			],
+			"flags": {
+				"midiProperties": {
+					"toggleEffect": true
+				}
+			},
+			"itemMacro": "PHB_bullseye-lantern.js"
+		},
+		{
+			"name": "Goggles of Night",
+			"source": "DMG",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "macro.itemMacro",
+							"mode": "CUSTOM",
+							"value": "@token"
+						}
+					],
+					"transfer": true,
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						}
+					}
+				}
+			],
+			"flags": {
+				"midiProperties": {
+					"toggleEffect": true
+				}
+			},
+			"itemMacro": "DMG_goggles-of-night.js"
+		},
+		{
+			"name": "Lantern of Revealing",
+			"source": "DMG",
+			"effects": [
+				{
+					"duration": {
+						"seconds": 21600
+					},
+					"changes": [
+						{
+							"key": "macro.itemMacro",
+							"mode": "ADD",
+							"value": ""
+						}
+					]
+				}
+			],
+			"flags": {
+				"midiProperties": {
+					"toggleEffect": true
+				}
+			},
+			"itemMacro": "DMG_lantern-of-revealing.js"
+		},
+		{
+			"name": "Mace of Disruption",
+			"source": "DMG",
+			"_TODO": [
+				"ItemMacro always runs, regardless of target's type."
+			],
+			"system": {
+				"activation.condition": "[\"fiend\", \"undead\"].includes(raceOrType)  && item.attunement !== 1"
+			},
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "StatusEffect",
+							"mode": "CUSTOM",
+							"value": "Convenient Effect: Frightened"
+						}
+					],
+					"duration": {
+						"rounds": 99
+					},
+					"flags": {
+						"dae": {
+							"specialDuration": [
+								"turnEndSource"
+							]
+						}
+					}
+				},
+				{
+					"changes": [
+						{
+							"key": "ATL.brightLight",
+							"mode": "UPGRADE",
+							"value": "20",
+							"priority": 20
+						},
+						{
+							"key": "ATL.dimLight",
+							"mode": "UPGRADE",
+							"value": "40",
+							"priority": 20
+						}
+					],
+					"transfer": true,
+					"requires": {
+						"ActiveAuras": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[preDamageApplication]ItemMacro",
+					"effectActivation": true
+				}
+			}
+		},
+		{
 			"name": "Sentinel Shield",
 			"source": "DMG",
 			"effects": [
@@ -19,6 +151,84 @@
 			"_merge": {
 				"effects": true
 			}
+		}
+	],
+	"magicvariant": [
+		{
+			"name": "Sword of Life Stealing",
+			"source": "DMG",
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro"
+				},
+				"midiProperties": {
+					"rollOther": true
+				}
+			},
+			"itemMacro": "DMG_sword-of-life-stealing.js"
+		},
+		{
+			"name": "Sword of Sharpness",
+			"source": "DMG",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "ATL.dimLight",
+							"mode": "ADD",
+							"value": "20"
+						},
+						{
+							"key": "ATL.brightLight",
+							"mode": "ADD",
+							"value": "10"
+						}
+					],
+					"transfer": true,
+					"requires": {
+						"ATL": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro"
+				},
+				"midiProperties": {
+					"rollOther": true
+				}
+			},
+			"itemMacro": "DMG_sword-of-sharpness.js"
+		},
+		{
+			"name": "Sword of Wounding",
+			"source": "DMG",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "macro.itemMacro",
+							"mode": "CUSTOM",
+							"value": "0"
+						}
+					],
+					"duration": {
+						"rounds": 99
+					},
+					"flags": {
+						"dae": {
+							"stackable": "count",
+							"macroRepeat": "startEveryTurn"
+						}
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro"
+				}
+			},
+			"itemMacro": "DMG_sword-of-wounding.js"
 		}
 	]
 }

--- a/script/build-task.js
+++ b/script/build-task.js
@@ -156,7 +156,7 @@ export const buildTask = async () => {
 						if (lines.at(-1) !== "}") throw new Error(`Expected macro "${macroPath}" to end with "\\n}"!`);
 
 						ent.itemMacro = lines
-							.slice(ixStart, -1)
+							.slice(ixStart + 1, -1)
 							.map(it => it.replace(/^\t/, ""))
 							.join("\n");
 

--- a/script/build-task.js
+++ b/script/build-task.js
@@ -145,10 +145,18 @@ export const buildTask = async () => {
 						if (!ent.itemMacro) return;
 
 						const macroPath = path.join(DIR_ITEM_MACROS, parentDir, ent.itemMacro);
-						ent.itemMacro = fs.readFileSync(macroPath, "utf-8")
+
+						const lines = fs.readFileSync(macroPath, "utf-8")
 							.trim()
-							.split("\n")
-							.slice(1, -1)
+							.split("\n");
+
+						const ixStart = lines.findIndex(l => l.startsWith("async function macro"));
+						if (!~ixStart) throw new Error(`Expected macro "${macroPath}" to include "async function macro ..."`);
+
+						if (lines.at(-1) !== "}") throw new Error(`Expected macro "${macroPath}" to end with "\\n}"!`);
+
+						ent.itemMacro = lines
+							.slice(ixStart, -1)
 							.map(it => it.replace(/^\t/, ""))
 							.join("\n");
 

--- a/test/schema/core.json
+++ b/test/schema/core.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "core.json",
-	"version": "0.1.2",
+	"version": "0.1.3",
 
 	"type": "object",
 
@@ -15,6 +15,7 @@
 		"action": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
 		"item": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
 		"itemGroup": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
+		"magicvariant": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
 		"baseitem": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
 		"variant": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
 		"background": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},

--- a/test/schema/homebrew.json
+++ b/test/schema/homebrew.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "homebrew.json",
-	"version": "0.1.2",
+	"version": "0.1.3",
 
 	"$comment": "Note: for homebrew files (i.e., those *not* names \"__core.json\"), the file should be named `<brewSourceJson>.json`, where <brewSourceJson> matches the `\"json\": \"MySourceName\"` value for the corresponding source in the homebrew repository.",
 
@@ -50,6 +50,7 @@
 		"action": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
 		"item": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
 		"itemGroup": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
+		"magicvariant": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
 		"baseitem": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
 		"variant": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},
 		"background": {"$ref": "shared.json#/$defs/foundrySideDataGenericArray"},

--- a/tool/public/client.js
+++ b/tool/public/client.js
@@ -154,9 +154,12 @@ class FlagConverter {
 					case "srd5e":
 					case "plutonium":
 					case "core":
+					case "exportSource":
 					case "favtab": // https://foundryvtt.com/packages/favtab
 					case "magicitems": // https://foundryvtt.com/packages/magicitems
 					case "cf": // https://foundryvtt.com/packages/compendium-folders (?)
+					case "scene-packer": // https://foundryvtt.com/packages/scene-packer
+					case "betterRolls5e": // https://foundryvtt.com/packages/betterrolls5e/
 						break;
 						// endregion
 


### PR DESCRIPTION
MidiQOL's compendium is a bit too junky to use directly, so simply filch the "good" bits.

Additional work to improve tooling, and add support for `magicvariant`s to cut down on item data copy-pasting (this is _partially_ supported in Plutonium currently; full support to be added for next release).