### PR TITLE
Fix level scaling for XGE_toll-the-dead.js

### DIFF
--- a/macro-item/spell/XGE_toll-the-dead.js
+++ b/macro-item/spell/XGE_toll-the-dead.js
@@ -6,7 +6,11 @@ async function macro (args) {
 	const needsD12 = target.actor.system.attributes.hp.value < target.actor.system.attributes.hp.max;
 	const theItem = await fromUuid(args[0].uuid);
 	let formula = theItem.system.damage.parts[0][0];
+	let scaling = theItem.system.scaling.formula;
 	if (needsD12) formula = formula.replace("d8", "d12");
 	else formula = formula.replace("d12", "d8");
+	if (needsD12) scaling = scaling.replace("d8", "d12");
+	else scaling = scaling.replace("d12", "d8");
 	theItem.system.damage.parts[0][0] = formula;
+	theItem.system.scaling.formula = scaling;
 }


### PR DESCRIPTION
The level scaling dice was not being edited by the old macro.  This adds a section to resolve this issue.