### PR TITLE
Add integration with Chris's Premades

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Installation](#installation)
    - [Dependencies and incompatibilities](#dependencies-and-incompatibilities)
    - [**Required** set-up](#required-set-up) (⚠️ **read this!**)
+   - [Optional integrations](#optional-integrations)
 - [Contributing](#contributing)
 
 ---
@@ -56,6 +57,13 @@ If you have [Item Macro](https://foundryvtt.com/packages/itemacro) activated, yo
 - _**Item Macro** > Override default macro execution_ — uncheck this.
 - _**Item Macro** > Character Sheet Hook_ — uncheck this.
 - (If installed) _**[Token Action HUD](https://foundryvtt.com/packages/token-action-hud)** > Item-Macro: item macro, original item, or both_ — select `Show the original item`. (Note this is a user setting, so either ensure that each user configures this or use a module such as [Force Client Settings](https://foundryvtt.com/packages/force-client-settings) to guarantee it.)
+
+### Optional integrations
+
+*Plutonium Addon: Automation* can optionally make use of data provided by other modules. An integration is available for:
+- [Chris's Premades](https://foundryvtt.com/packages/chris-premades)
+
+This integration is only active if the above module is installed and active, and can be disabled in *Plutonium Addon: Automation*'s settings.
 
 ## Contributing
 

--- a/module/js/DataManager.js
+++ b/module/js/DataManager.js
@@ -1,155 +1,27 @@
-import {SharedConsts} from "../shared/SharedConsts.js";
-import {OptionalDependenciesManager} from "./OptionalDependenciesManager.js";
+import {DataSourceSelf} from "./data-source/DataSourceSelf.js";
+import {DataSourceIntegrations} from "./data-source/DataSourceIntegrations.js";
 
 export class DataManager {
-	static #P_INDEX = null;
-
 	static async api_pGetExpandedAddonData (
 		{
 			propJson,
 			path,
 			fnMatch,
+			ent,
 			isSilent = false,
 		},
 	) {
-		const index = await (this.#P_INDEX = this.#P_INDEX || DataUtil.loadJSON(`${SharedConsts.MODULE_PATH}/data/_generated/index.json`));
+		const dataSources = [
+			DataSourceSelf,
+			DataSourceIntegrations,
+		];
 
-		const ixFile = MiscUtil.get(index, propJson, ...path);
-		if (ixFile == null) return null;
-
-		const json = await DataUtil.loadJSON(`${SharedConsts.MODULE_PATH}/data/${index._file[ixFile]}`);
-
-		const out = (json?.[propJson] || [])
-			.find(it => fnMatch(it));
-		if (!out) return null;
-
-		return this._getFilteredOutput(
-			this._getPostProcessed(
-				this._getFilteredInput(
-					out,
-					{isSilent},
-				),
-			),
-			{isSilent},
-		);
-	}
-
-	static _getFilteredInput (out, {isSilent}) {
-		out = this._getFilteredInput_itemMacro({out, isSilent});
-		return out;
-	}
-
-	static _getFilteredInput_itemMacro ({out, isSilent}) {
-		if (this._isRequiresMatch(out.itemMacro?.requires, {isSilent})) return out;
-
-		out = foundry.utils.deepClone(out);
-		delete out.itemMacro;
-		return out;
-	}
-
-	static _getPostProcessed (out) {
-		out = this._getPostProcessed_effects({out});
-		out = this._getPostProcessed_itemMacro({out});
-		return out;
-	}
-
-	static _getPostProcessed_effects ({out}) {
-		if (!out.effects?.some(({convenientEffect}) => !!convenientEffect)) return out;
-
-		out = foundry.utils.deepClone(out);
-
-		out.effects = out.effects.map(eff => {
-			if (!eff.convenientEffect) return eff;
-
-			const convEffect = game.dfreds.effectInterface.findEffectByName(eff.convenientEffect);
-			if (!convEffect) return eff;
-
-			const convEffectData = convEffect.convertToActiveEffectData
-				// DCE < v4.0.0
-				? convEffect.convertToActiveEffectData({
-					includeAte: game.modules.get("ATL")?.active,
-					includeTokenMagic: game.modules.get("tokenmagic")?.active,
-				})
-				// DCE >= v4.0.0
-				: convEffect.toObject(true);
-
-			delete eff.convenientEffect;
-
-			return foundry.utils.mergeObject(
-				convEffectData,
-				{
-					// region Convert to our alternate field names, which are prioritized. This ensures the CE name/image
-					//   will be used over a name/image generated from the parent document.
-					name: convEffectData.label,
-					img: convEffectData.icon,
-					// endregion
-					...eff,
-
-					// Override CE's built-in IDs, as they are not valid (e.g. `"id": "Convenient Effect: Invisible"`),
-					//   which causes issues when creating temporary actors (e.g. when using Quick Insert to view a
-					//   creature).
-					// (N.b.: No longer required as of CE v4.0.0)
-					id: foundry.utils.randomID(),
-				},
-			);
-		});
-
-		return out;
-	}
-
-	static _getPostProcessed_itemMacro ({out}) {
-		if (!out.itemMacro) return out;
-
-		out = foundry.utils.deepClone(out);
-
-		out.flags = out.flags || {};
-		out.flags.itemacro = {
-			"macro": {
-				"_id": null,
-				"name": "-",
-				"type": "script",
-				"author": game.userId,
-				"img": "icons/svg/dice-target.svg",
-				"scope": "global",
-				"command": out.itemMacro.script,
-				"folder": null,
-				"sort": 0,
-				"ownership": {"default": 0},
-				"flags": {},
-			},
-		};
-
-		delete out.itemMacro;
-
-		return out;
-	}
-
-	static _getFilteredOutput (out, {isSilent}) {
-		out = this._getFilteredOutput_effects({out, isSilent});
-		return out;
-	}
-
-	static _getFilteredOutput_effects ({out, isSilent}) {
-		if (!out.effects?.some(({requires}) => !!requires)) return out;
-
-		out = foundry.utils.deepClone(out);
-
-		out.effects = out.effects
-			.filter(eff => this._isRequiresMatch(eff.requires, {isSilent}));
-
-		return out;
-	}
-
-	static _isRequiresMatch (requiresObj, {isSilent}) {
-		if (!requiresObj) return true;
-
-		return Object.keys(requiresObj)
-			.map(moduleId => {
-				if (game.modules.get(moduleId)?.active) return true;
-				if (!isSilent) OptionalDependenciesManager.doNotifyMissing(moduleId);
-				return false;
-			})
-			// Avoid using `.every` directly, above, so that we run through all possible requirements
-			.every(Boolean);
+		return dataSources.pSerialAwaitFirst(dataSource => dataSource.pGetExpandedAddonData({
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent,
+		}));
 	}
 }

--- a/module/js/Main.js
+++ b/module/js/Main.js
@@ -3,6 +3,7 @@ import {Util} from "./Util.js";
 import {OptionalDependenciesManager} from "./OptionalDependenciesManager.js";
 import {SettingsManager} from "./SettingsManager.js";
 import {Api} from "./Api.js";
+import {Integrations} from "./integrations/Integrations.js";
 
 class Main {
 	static _HAS_FAILED = false;
@@ -19,6 +20,7 @@ class Main {
 	static _handleInit () {
 		SettingsManager.handleInit();
 		OptionalDependenciesManager.handleInit();
+		Integrations.handleInit();
 	}
 
 	static handleReady () {
@@ -34,6 +36,7 @@ class Main {
 		Api.handleReady();
 		SettingsManager.handleReady();
 		OptionalDependenciesManager.handleReady();
+		Integrations.handleReady();
 		console.log(...Util.LGT, `Initialized.`);
 	}
 

--- a/module/js/data-source/DataSourceBase.js
+++ b/module/js/data-source/DataSourceBase.js
@@ -1,0 +1,12 @@
+/** @abstract */
+export class DataSourceBase {
+	static async pGetExpandedAddonData (
+		{
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent = false,
+		},
+	) { throw new Error("Unimplemented!"); }
+}

--- a/module/js/data-source/DataSourceIntegrations.js
+++ b/module/js/data-source/DataSourceIntegrations.js
@@ -1,0 +1,22 @@
+import {DataSourceBase} from "./DataSourceBase.js";
+import {Integrations} from "../integrations/Integrations.js";
+
+export class DataSourceIntegrations extends DataSourceBase {
+	static async pGetExpandedAddonData (
+		{
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent = false,
+		},
+	) {
+		return Integrations.pGetExpandedAddonData({
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent,
+		});
+	}
+}

--- a/module/js/data-source/DataSourceSelf.js
+++ b/module/js/data-source/DataSourceSelf.js
@@ -1,0 +1,157 @@
+import {SharedConsts} from "../../shared/SharedConsts.js";
+import {OptionalDependenciesManager} from "../OptionalDependenciesManager.js";
+import {DataSourceBase} from "./DataSourceBase.js";
+
+export class DataSourceSelf extends DataSourceBase {
+	static #P_INDEX = null;
+
+	static async pGetExpandedAddonData (
+		{
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent = false,
+		},
+	) {
+		const index = await (this.#P_INDEX = this.#P_INDEX || DataUtil.loadJSON(`${SharedConsts.MODULE_PATH}/data/_generated/index.json`));
+
+		const ixFile = MiscUtil.get(index, propJson, ...path);
+		if (ixFile == null) return null;
+
+		const json = await DataUtil.loadJSON(`${SharedConsts.MODULE_PATH}/data/${index._file[ixFile]}`);
+
+		const out = (json?.[propJson] || [])
+			.find(it => fnMatch(it));
+		if (!out) return null;
+
+		return this._getFilteredOutput(
+			this._getPostProcessed(
+				this._getFilteredInput(
+					out,
+					{isSilent},
+				),
+			),
+			{isSilent},
+		);
+	}
+
+	static _getFilteredInput (out, {isSilent}) {
+		out = this._getFilteredInput_itemMacro({out, isSilent});
+		return out;
+	}
+
+	static _getFilteredInput_itemMacro ({out, isSilent}) {
+		if (this._isRequiresMatch(out.itemMacro?.requires, {isSilent})) return out;
+
+		out = foundry.utils.deepClone(out);
+		delete out.itemMacro;
+		return out;
+	}
+
+	static _getPostProcessed (out) {
+		out = this._getPostProcessed_effects({out});
+		out = this._getPostProcessed_itemMacro({out});
+		return out;
+	}
+
+	static _getPostProcessed_effects ({out}) {
+		if (!out.effects?.some(({convenientEffect}) => !!convenientEffect)) return out;
+
+		out = foundry.utils.deepClone(out);
+
+		out.effects = out.effects.map(eff => {
+			if (!eff.convenientEffect) return eff;
+
+			const convEffect = game.dfreds.effectInterface.findEffectByName(eff.convenientEffect);
+			if (!convEffect) return eff;
+
+			const convEffectData = convEffect.convertToActiveEffectData
+				// DCE < v4.0.0
+				? convEffect.convertToActiveEffectData({
+					includeAte: game.modules.get("ATL")?.active,
+					includeTokenMagic: game.modules.get("tokenmagic")?.active,
+				})
+				// DCE >= v4.0.0
+				: convEffect.toObject(true);
+
+			delete eff.convenientEffect;
+
+			return foundry.utils.mergeObject(
+				convEffectData,
+				{
+					// region Convert to our alternate field names, which are prioritized. This ensures the CE name/image
+					//   will be used over a name/image generated from the parent document.
+					name: convEffectData.label,
+					img: convEffectData.icon,
+					// endregion
+					...eff,
+
+					// Override CE's built-in IDs, as they are not valid (e.g. `"id": "Convenient Effect: Invisible"`),
+					//   which causes issues when creating temporary actors (e.g. when using Quick Insert to view a
+					//   creature).
+					// (N.b.: No longer required as of CE v4.0.0)
+					id: foundry.utils.randomID(),
+				},
+			);
+		});
+
+		return out;
+	}
+
+	static _getPostProcessed_itemMacro ({out}) {
+		if (!out.itemMacro) return out;
+
+		out = foundry.utils.deepClone(out);
+
+		out.flags = out.flags || {};
+		out.flags.itemacro = {
+			"macro": {
+				"_id": null,
+				"name": "-",
+				"type": "script",
+				"author": game.userId,
+				"img": "icons/svg/dice-target.svg",
+				"scope": "global",
+				"command": out.itemMacro.script,
+				"folder": null,
+				"sort": 0,
+				"ownership": {"default": 0},
+				"flags": {},
+			},
+		};
+
+		delete out.itemMacro;
+
+		return out;
+	}
+
+	static _getFilteredOutput (out, {isSilent}) {
+		out = this._getFilteredOutput_effects({out, isSilent});
+		return out;
+	}
+
+	static _getFilteredOutput_effects ({out, isSilent}) {
+		if (!out.effects?.some(({requires}) => !!requires)) return out;
+
+		out = foundry.utils.deepClone(out);
+
+		out.effects = out.effects
+			.filter(eff => this._isRequiresMatch(eff.requires, {isSilent}));
+
+		return out;
+	}
+
+	static _isRequiresMatch (requiresObj, {isSilent}) {
+		if (!requiresObj) return true;
+
+		return Object.keys(requiresObj)
+			.map(moduleId => {
+				if (game.modules.get(moduleId)?.active) return true;
+				if (!isSilent) OptionalDependenciesManager.doNotifyMissing(moduleId);
+				return false;
+			})
+			// Avoid using `.every` directly, above, so that we run through all possible requirements
+			.every(Boolean);
+	}
+}

--- a/module/js/integrations/ChrisPremades.js
+++ b/module/js/integrations/ChrisPremades.js
@@ -1,0 +1,227 @@
+import {IntegrationBase} from "./IntegrationBase.js";
+import {SharedConsts} from "../../shared/SharedConsts.js";
+
+// Cheat and pretend we're not always overriding, as our patches are temporary/highly contextual
+const _LIBWRAPPER_TYPE_TEMP = "MIXED";
+
+/**
+ * Designed for use with `chris-premades` v0.3.7
+ * See: https://github.com/chrisk123999/chris-premades
+ */
+export class IntegrationChrisPremades extends IntegrationBase {
+	_moduleId = "chris-premades";
+
+	_handleInit () {
+		libWrapper.register(SharedConsts.MODULE_ID, "Hooks.on", this._lw_Hooks_on.bind(this), _LIBWRAPPER_TYPE_TEMP);
+	}
+
+	_hook_createHeaderButton = null;
+	_lw_Hooks_on (fn, ...args) {
+		const [hookId, fnHook] = args;
+		if (
+			hookId !== "getItemSheetHeaderButtons"
+			|| this._hook_createHeaderButton
+			|| fnHook.name !== "createHeaderButton"
+			|| !fnHook.toString().includes(this._moduleId)
+		) return fn(...args);
+		this._hook_createHeaderButton = fnHook;
+		return fn(...args);
+	}
+
+	_stubSemaphores = {};
+
+	async _pWithStubbed (nameStubbed, fn, {returnValue} = {}) {
+		let out;
+		// Only register/deregister on semaphore 0 to avoid libWrapper errors (a module may only patch a method once)
+		try {
+			this._stubSemaphores[nameStubbed] = this._stubSemaphores[nameStubbed] || 0;
+			if (!this._stubSemaphores[nameStubbed]++) {
+				libWrapper.register(SharedConsts.MODULE_ID, nameStubbed, () => returnValue, _LIBWRAPPER_TYPE_TEMP);
+			}
+			out = await fn();
+		} finally {
+			if (!--this._stubSemaphores[nameStubbed]) {
+				libWrapper.unregister(SharedConsts.MODULE_ID, nameStubbed, false);
+				delete this._stubSemaphores[nameStubbed];
+			}
+		}
+		return out;
+	}
+
+	_propsJsonBlocklist = new Set([
+		"monster",
+		"trap",
+		"object",
+		"vehicle",
+	]);
+
+	async pGetExpandedAddonData (
+		{
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent = false,
+		},
+	) {
+		if (
+			!this._hook_createHeaderButton
+			|| !SourceUtil.isSiteSource(ent.source)
+			|| this._propsJsonBlocklist.has(propJson)
+		) return null;
+
+		return this._pGetExpandedAddonData_pWithStubs({
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent,
+		});
+	}
+
+	async _pGetExpandedAddonData_pWithStubs (
+		{
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent = false,
+		},
+	) {
+		return this._pWithStubbed(
+			"ui.notifications.info",
+			() => this._pWithStubbed(
+				"chrisPremades.helpers.dialog",
+				() => this._pWithStubbed(
+					"ChatMessage.create",
+					this._pGetExpandedAddonData_pWithStubbed
+						.bind(
+							this,
+							{
+								propJson,
+								path,
+								fnMatch,
+								ent,
+								isSilent,
+							},
+						),
+				),
+				{
+					returnValue: true,
+				},
+			),
+		);
+	}
+
+	async _pGetExpandedAddonData_pWithStubbed (
+		{
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent = false,
+		},
+	) {
+		// Create a fake actor to bypass CPR's `doc.actor` check
+		const fauxActor = new (class {
+			// TODO(Future) return `"npc"` if this is a creature embedded item (requires Plutonium support/reworks)
+			get type () {
+				return "character";
+			}
+
+			_embeddedItems = null;
+
+			get firstEmbeddedItem () { return this._embeddedItems?.[0]; }
+
+			createEmbeddedDocuments (docType, embeds) {
+				if (docType !== "Item") return;
+				this._embeddedItems = embeds;
+			}
+		})();
+
+		// Override the Foundry type based on our entity type
+		const type = this._pGetExpandedAddonData_getItemType({propJson});
+
+		// Create a stubbed `Item` subclass to bypass CPR's `instanceof Item` check
+		const fauxObject = new class extends Item {
+			get actor () { return fauxActor; }
+			set actor (val) { /* No-op */ }
+
+			delete () { /* No-op */ }
+		}({
+			name: ent.name,
+			type,
+		});
+
+		const jsonEmpty = fauxObject.toObject(true);
+
+		// region Create a fake "sheet" config such that we can run the per-item onclick bind
+		const fauxConfig = {object: fauxObject};
+		const fauxButtons = [];
+		this._hook_createHeaderButton(fauxConfig, fauxButtons);
+		await fauxButtons[0].onclick(fauxConfig);
+		// endregion
+
+		const jsonFilled = fauxActor.firstEmbeddedItem;
+		if (!jsonFilled) return null;
+
+		if (foundry.utils.objectsEqual(jsonEmpty, jsonFilled)) return null;
+
+		const jsonDiff = foundry.utils.diffObject(jsonEmpty, jsonFilled);
+
+		return this._pGetExpandedAddonData_getPostProcessed(jsonDiff);
+	}
+
+	_pGetExpandedAddonData_getItemType ({propJson}) {
+		if (UrlUtil.PAGE_TO_PROPS[UrlUtil.PG_SPELLS].includes(propJson)) return "spell";
+		if (UrlUtil.PAGE_TO_PROPS[UrlUtil.PG_ITEMS].includes(propJson)) return "equipment";
+		return "feat";
+	}
+
+	_pGetExpandedAddonData_getPostProcessed (fauxItemJson) {
+		fauxItemJson = foundry.utils.deepClone(fauxItemJson);
+
+		// Avoid clobbering specific system data
+		["name", "source", "description"].forEach(prop => delete fauxItemJson.system[prop]);
+
+		// Remove junk flags
+		// Commented-out flag keys are present in the data, but are flags we wish to keep
+		[
+			// "autoanimations",
+			// "babonus",
+			"betterRolls5e",
+			"cf",
+			// "chris-premades",
+			"core",
+			"custom-character-sheet-sections",
+			// "dae",
+			"ddbimporter",
+			// "enhanced-terrain-layer",
+			"exportSource",
+			"favtab",
+			"infusions",
+			"inventory-plus",
+			// "itemacro",
+			// "link-item-resource-5e",
+			// "magicitems",
+			// "midi-qol",
+			// "midiProperties",
+			"monsterMunch",
+			"obsidian",
+			// "rest-recovery",
+			"spell-class-filter-for-5e",
+			// "templatemacro",
+			"tidy5e-sheet",
+			"world",
+		].forEach(prop => delete fauxItemJson.flags[prop]);
+
+		// Cleanup
+		if (!Object.keys(fauxItemJson.system || {}).length) delete fauxItemJson.system;
+		if (!Object.keys(fauxItemJson.flags || {}).length) delete fauxItemJson.flags;
+		if (!fauxItemJson.effects?.length) delete fauxItemJson.effects;
+
+		if (!Object.keys(fauxItemJson).length) return null;
+
+		return fauxItemJson;
+	}
+}

--- a/module/js/integrations/IntegrationBase.js
+++ b/module/js/integrations/IntegrationBase.js
@@ -1,0 +1,58 @@
+import {SharedConsts} from "../../shared/SharedConsts.js";
+
+/** @abstract */
+export class IntegrationBase {
+	_moduleId;
+
+	get _settingKeyIsEnabled () { return `isIntegrationEnabled_${this._moduleId}`; }
+
+	_isModuleActive () { return game.modules.get(this._moduleId)?.active; }
+	_isEnabled () { return game.settings.get(SharedConsts.MODULE_ID, this._settingKeyIsEnabled); }
+	_isActive () { return this._isModuleActive() && this._isEnabled(); }
+
+	handleInit () {
+		// Register the setting regardless of whether or not the module is available, as a hint to the user that the
+		//    integration exists.
+		this._handleInit_registerSettings();
+
+		if (!this._isActive()) return;
+		this._handleInit();
+	}
+
+	_handleInit_registerSettings () {
+		const moduleTitle = game.modules.get(this._moduleId)?.title || this._moduleId;
+
+		game.settings.register(
+			SharedConsts.MODULE_ID,
+			this._settingKeyIsEnabled,
+			{
+				name: `Enable Integration with ${moduleTitle}`, // Note that `game.i18n.format` does not work during `init`
+				hint: `If enabled, and the "${moduleTitle}" module is active, ${SharedConsts.MODULE_TITLE} will make use of data made available by ${moduleTitle}.`,
+				default: true,
+				type: Boolean,
+				scope: "world",
+				config: true,
+				requiresReload: true,
+			},
+		);
+	}
+
+	handleReady () {
+		if (!this._isActive()) return;
+		this._handleReady();
+	}
+
+	_handleInit () { /* Implement as required */ }
+	_handleReady () { /* Implement as required */ }
+
+	/** @abstract */
+	async pGetExpandedAddonData (
+		{
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent = false,
+		},
+	) { throw new Error("Unimplemented!"); }
+}

--- a/module/js/integrations/Integrations.js
+++ b/module/js/integrations/Integrations.js
@@ -1,0 +1,28 @@
+import {IntegrationChrisPremades} from "./ChrisPremades.js";
+
+export class Integrations {
+	static _INTEGRATIONS = [
+		new IntegrationChrisPremades(),
+	];
+
+	static handleInit () { this._INTEGRATIONS.forEach(itg => itg.handleInit()); }
+	static handleReady () { this._INTEGRATIONS.forEach(itg => itg.handleReady()); }
+
+	static async pGetExpandedAddonData (
+		{
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent = false,
+		},
+	) {
+		return this._INTEGRATIONS.pSerialAwaitFirst(itg => itg.pGetExpandedAddonData({
+			propJson,
+			path,
+			fnMatch,
+			ent,
+			isSilent,
+		}));
+	}
+}

--- a/script/build-task.js
+++ b/script/build-task.js
@@ -71,6 +71,11 @@ export const buildTask = async (
 				*/
 				// endregion
 				{
+					id: "lib-wrapper",
+					type: "module",
+					manifest: "https://github.com/ruipin/fvtt-lib-wrapper/releases/latest/download/module.json",
+				},
+				{
 					id: "midi-qol",
 					type: "module",
 					manifest: "https://gitlab.com/tposney/midi-qol/raw/v10/package/module.json",


### PR DESCRIPTION
This allows PAA to grab item data from CPR, and return it in a format which Plutonium can use. Note if both PAA and CPR have data for an item, then PAA's version takes priority (i.e., the two are *not* merged).

See: https://foundryvtt.com/packages/chris-premades

Closes #86

---

Here's an example of a before/after for Heat Metal

```diff
2c2
<   "name": "Heat Metal (Without)",
---
>   "name": "Heat Metal (With)",
24c24
<       "type": "object"
---
>       "type": "creature"
45c45
<     "chatFlavor": "",
---
>     "chatFlavor": "[2d8 - fire] Use a bonus action on each subsequent turn to cause this damage again",
53c53
<           "2d8",
---
>           "2d8[fire]",
61c61
<       "ability": "con",
---
>       "ability": "",
96a97,136
>     "ddbimporter": {
>       "id": 138066,
>       "definitionId": 2141,
>       "entityTypeId": 435869154,
>       "dndbeyond": {
>         "lookup": "generic",
>         "lookupName": "generic",
>         "level": null,
>         "castAtLevel": null
>       },
>       "originalName": "Heat Metal",
>       "sources": [
>         {
>           "sourceId": 1,
>           "pageNumber": null,
>           "sourceType": 2
>         },
>         {
>           "sourceId": 2,
>           "pageNumber": 250,
>           "sourceType": 1
>         }
>       ],
>       "tags": [
>         "Damage",
>         "Debuff"
>       ],
>       "version": "3.3.10",
>       "effectsApplied": true
>     },
>     "custom-character-sheet-sections": {
>       "sectionName": ""
>     },
>     "rest-recovery": {
>       "data": {
>         "recovery": {
>           "enabled": false
>         }
>       }
>     },
98c138,139
<       "effectActivation": false
---
>       "effectActivation": false,
>       "onUseMacroName": "[postActiveEffects]function.await chrisPremades.macros.heatMetal.item"
114a156,180
>     "itemacro": {
>       "macro": {
>         "name": "Heat Metal",
>         "type": "script",
>         "scope": "global",
>         "command": "",
>         "author": "PQGBBcoVSwpUhViM",
>         "_id": null,
>         "img": "icons/svg/dice-target.svg",
>         "folder": null,
>         "sort": 0,
>         "ownership": {
>           "default": 0
>         },
>         "flags": {},
>         "_stats": {
>           "systemId": null,
>           "systemVersion": null,
>           "coreVersion": null,
>           "createdTime": null,
>           "modifiedTime": null,
>           "lastModifiedBy": null
>         }
>       }
>     },
```