### PR TITLE
Add an optional warning when importing a non-automated entity 

### DIFF
--- a/module/js/Api.js
+++ b/module/js/Api.js
@@ -6,7 +6,7 @@ import {StartupHookMixin} from "./mixins/MixinStartupHooks.js";
  * @mixes {StartupHookMixin}
  */
 export class Api extends StartupHookMixin(class {}) {
-	static onHookReady () {
+	static _onHookReady () {
 		game.modules.get(SharedConsts.MODULE_ID).api = this;
 	}
 

--- a/module/js/DataManager.js
+++ b/module/js/DataManager.js
@@ -1,7 +1,45 @@
 import {DataSourceSelf} from "./data-source/DataSourceSelf.js";
 import {DataSourceIntegrations} from "./data-source/DataSourceIntegrations.js";
+import {SharedConsts} from "../shared/SharedConsts.js";
+import {ModuleSettingConsts} from "./ModuleSettingConsts.js";
+import {StartupHookMixin} from "./mixins/MixinStartupHooks.js";
+import {Util} from "./Util.js";
 
-export class DataManager {
+export class DataManager extends StartupHookMixin(class {}) {
+	static _onHookInitDev () {
+		game.settings.register(
+			SharedConsts.MODULE_ID,
+			ModuleSettingConsts.DEV_IS_WARN_WHEN_NOT_AUTOMATED,
+			{
+				name: "PLUTAA.Developer: Warn when Not Automated",
+				hint: "Log a message when a non-automated document is imported.",
+				default: false,
+				type: Boolean,
+				scope: "client",
+				config: true,
+				restricted: true,
+			},
+		);
+	}
+
+	/* -------------------------------------------- */
+
+	static _LOGGED_IDENTIFIERS = new Set();
+
+	static _doDevWarn ({ent, out}) {
+		if (out) return;
+		if (!game.settings.get(SharedConsts.MODULE_ID, ModuleSettingConsts.DEV_IS_WARN_WHEN_NOT_AUTOMATED)) return;
+
+		const ident = `${ent.name} (${ent.source})`;
+
+		if (this._LOGGED_IDENTIFIERS.has(ident)) return;
+		this._LOGGED_IDENTIFIERS.add(ident);
+
+		console.warn(...Util.LGT, `No automation found for: ${ident}`);
+	}
+
+	/* -------------------------------------------- */
+
 	static async api_pGetExpandedAddonData (
 		{
 			propJson,
@@ -16,12 +54,16 @@ export class DataManager {
 			DataSourceIntegrations,
 		];
 
-		return dataSources.pSerialAwaitFirst(dataSource => dataSource.pGetExpandedAddonData({
+		const out = await dataSources.pSerialAwaitFirst(dataSource => dataSource.pGetExpandedAddonData({
 			propJson,
 			path,
 			fnMatch,
 			ent,
 			isSilent,
 		}));
+
+		this._doDevWarn({ent, out});
+
+		return out;
 	}
 }

--- a/module/js/Main.js
+++ b/module/js/Main.js
@@ -4,6 +4,7 @@ import {OptionalDependenciesManager} from "./OptionalDependenciesManager.js";
 import {SettingsManager} from "./SettingsManager.js";
 import {Api} from "./Api.js";
 import {Integrations} from "./integrations/Integrations.js";
+import {DataManager} from "./DataManager.js";
 
 class Main {
 	static _HAS_FAILED = false;
@@ -13,6 +14,7 @@ class Main {
 		SettingsManager,
 		OptionalDependenciesManager,
 		Integrations,
+		DataManager,
 	];
 
 	static onHookInit () {
@@ -26,7 +28,8 @@ class Main {
 
 	static _onHookInit () {
 		this._STARTUP_CLAZZES
-			.forEach(clazz => clazz.onHookInit());
+			.map(clazz => clazz.onHookInit())
+			.map(clazz => clazz.onHookInitDev());
 	}
 
 	static onHookReady () {
@@ -40,7 +43,8 @@ class Main {
 
 	static _onHookReady () {
 		this._STARTUP_CLAZZES
-			.forEach(clazz => clazz.onHookReady());
+			.map(clazz => clazz.onHookReady())
+			.map(clazz => clazz.onHookReadyDev());
 
 		console.log(...Util.LGT, `Initialized.`);
 	}

--- a/module/js/ModuleSettingConsts.js
+++ b/module/js/ModuleSettingConsts.js
@@ -3,4 +3,5 @@ export class ModuleSettingConsts {
 	static IS_NOTIFY_ON_LOAD = "isNotifyOnLoad";
 	static MENU_CONFIGURE_OPTIONAL_DEPENDENCIES = "menuConfigureOptionalDependencies";
 	static OPTIONAL_DEPENDENCY_NOTIFICATION_CONFIG = "optionalDependencyNotificationConfig";
+	static DEV_IS_WARN_WHEN_NOT_AUTOMATED = "dev_isWarnWhenNotAutomated";
 }

--- a/module/js/OptionalDependenciesManager.js
+++ b/module/js/OptionalDependenciesManager.js
@@ -57,7 +57,7 @@ export class OptionalDependenciesManager extends StartupHookMixin(class {}) {
 
 	/* -------------------------------------------- */
 
-	static onHookInit () {
+	static _onHookInit () {
 		game.settings.registerMenu(
 			SharedConsts.MODULE_ID,
 			ModuleSettingConsts.MENU_CONFIGURE_OPTIONAL_DEPENDENCIES,
@@ -85,7 +85,7 @@ export class OptionalDependenciesManager extends StartupHookMixin(class {}) {
 
 	/* -------------------------------------------- */
 
-	static onHookReady () {
+	static _onHookReady () {
 		$(document.body)
 			.on("click", `[data-paa-module-ids]`, async evt => {
 				const msgId = evt.currentTarget.closest(`[data-message-id]`).getAttribute("data-message-id");

--- a/module/js/SettingsManager.js
+++ b/module/js/SettingsManager.js
@@ -170,7 +170,7 @@ export class SettingsManager extends StartupHookMixin(class {}) {
 
 	/* -------------------------------------------- */
 
-	static onHookInit () {
+	static _onHookInit () {
 		game.settings.registerMenu(
 			SharedConsts.MODULE_ID,
 			ModuleSettingConsts.MENU_CONFIGURE_DEPENDENCIES,
@@ -201,7 +201,7 @@ export class SettingsManager extends StartupHookMixin(class {}) {
 
 	/* -------------------------------------------- */
 
-	static onHookReady () {
+	static _onHookReady () {
 		this._onHookReady_doPostCompatibilityNotification();
 	}
 

--- a/module/js/Util.js
+++ b/module/js/Util.js
@@ -1,6 +1,6 @@
 export class Util {
 	static LGT = [
-		`%cPlutonium Addon: Data`,
+		`%cPlutonium Addon: Automation`,
 		`color: #5494cc; font-weight: bold;`,
 		`|`,
 	];

--- a/module/js/integrations/Integrations.js
+++ b/module/js/integrations/Integrations.js
@@ -9,8 +9,8 @@ export class Integrations extends StartupHookMixin(class {}) {
 		new IntegrationChrisPremades(),
 	];
 
-	static onHookInit () { this._INTEGRATIONS.forEach(itg => itg.onHookInit()); }
-	static onHookReady () { this._INTEGRATIONS.forEach(itg => itg.onHookReady()); }
+	static _onHookInit () { this._INTEGRATIONS.forEach(itg => itg.onHookInit()); }
+	static _onHookReady () { this._INTEGRATIONS.forEach(itg => itg.onHookReady()); }
 
 	static async pGetExpandedAddonData (
 		{

--- a/module/js/mixins/MixinStartupHooks.js
+++ b/module/js/mixins/MixinStartupHooks.js
@@ -4,6 +4,37 @@
  * @mixin
  */
 export const StartupHookMixin = Base => class extends Base {
-	static onHookInit () { /* Implement as required */ }
-	static onHookReady () { /* Implement as required */ }
+	static onHookInit () {
+		this._onHookInit();
+		return this;
+	}
+
+	static _onHookInit () { /* Implement as required */ }
+
+	/* -------------------------------------------- */
+
+	static onHookInitDev () {
+		this._onHookInitDev();
+		return this;
+	}
+
+	static _onHookInitDev () { /* Implement as required */ }
+
+	/* -------------------------------------------- */
+
+	static onHookReady () {
+		this._onHookReady();
+		return this;
+	}
+
+	static _onHookReady () { /* Implement as required */ }
+
+	/* -------------------------------------------- */
+
+	static onHookReadyDev () {
+		this._onHookReadyDev();
+		return this;
+	}
+
+	static _onHookReadyDev () { /* Implement as required */ }
 };

--- a/module/lang/en.json
+++ b/module/lang/en.json
@@ -1,5 +1,6 @@
 {
 	"PLUTAA.Configure Dependencies": "Configure Dependencies",
 	"PLUTAA.Configure Notifications": "Configure Notifications",
-	"PLUTAA.Show Config on Load": "Show Config on Load"
+	"PLUTAA.Show Config on Load": "Show Config on Load",
+	"PLUTAA.Developer: Warn when Not Automated": "Developer: Warn when Not Automated"
 }


### PR DESCRIPTION
This makes it easier to brainlessly smash about and find things which have yet to be automated (although does nothing to handle "false positives," i.e., entities for which no automation is desired), in lieu of, say, a nice tracking system.