### PR TITLE
Add D&D Beyond Importer spell automations/macros

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright (c) 2022 TheGiddyLimit
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/docs/client.js
+++ b/docs/client.js
@@ -1,12 +1,19 @@
-"use strict";
+import {getMacroFilename} from "./shared/util.js";
+import {pDoDownloadZip} from "./util.js";
+import {flattenObject} from "./shared/foundry-helpers.js";
 
 class ConverterUi {
 	static _iptFile = null;
 	static _iptText = null;
+	static _cbKeepSystem = null;
 	static _cbKeepImg = null;
+	static _iptScriptHeader = null;
 	static _btnConvert = null;
 	static _btnCopy = null;
+	static _btnDownloadScripts = null;
 	static _outText = null;
+
+	static _converted = null;
 
 	static _onChange_file () {
 		const reader = new FileReader();
@@ -51,6 +58,15 @@ class ConverterUi {
 		window.setTimeout(() => this._btnCopy.innerHTML = "Copy", 500);
 	}
 
+	static async _pOnClick_btnDownloadScripts () {
+		await pDoDownloadZip(
+			"scripts.zip",
+			this._converted
+				.filter(it => it.script)
+				.map(({script}) => ({name: script.filename, data: script.script})),
+		);
+	}
+
 	static _doConvert () {
 		try {
 			this._doConvert_();
@@ -61,29 +77,77 @@ class ConverterUi {
 	}
 
 	static _doConvert_ () {
+		const json = JSON.parse(this._iptText.value);
+		const ipt = json instanceof Array
+			? json
+				.sort((a, b) => (a.flags?.srd5e?.page || "").localeCompare(b.flags?.srd5e?.page || "")
+					|| (a.type || "").localeCompare(b.type || "")
+					|| (a.name || "").localeCompare(b.name || "", {sensitivity: "base"}))
+			: [json];
+
+		this._converted = ipt.map(it => Converter.getConverted(
+			it,
+			{
+				isKeepSystem: this._cbKeepSystem.checked,
+				isKeepImg: this._cbKeepImg.checked,
+				scriptHeader: this._iptScriptHeader.value.trim(),
+			},
+		));
+		this._renderConverted();
+	}
+
+	static _renderConverted () {
 		this._outText.value = JSON.stringify(
-			Converter.getConverted(
-				JSON.parse(this._iptText.value),
-				{
-					isKeepImg: this._cbKeepImg.checked,
-				},
-			),
+			this._converted.map(it => it.data),
 			null,
 			"\t",
 		);
+
+		const withScripts = this._converted.filter(it => it.script);
+		this._btnDownloadScripts.innerText = `Download Scripts (${withScripts.length})`;
+		this._btnDownloadScripts.disabled = !withScripts.length;
 	}
 
-	static init () {
+	/* -------------------------------------------- */
+
+	static _pInit_elements () {
 		this._iptFile = document.getElementById("ipt-file");
 		this._iptText = document.getElementById("ipt-text");
+		this._cbKeepSystem = document.getElementById("cb-keep-system");
 		this._cbKeepImg = document.getElementById("cb-keep-img");
+		this._iptScriptHeader = document.getElementById("ipt-script-header");
 		this._btnConvert = document.getElementById("btn-convert");
 		this._btnCopy = document.getElementById("btn-copy");
+		this._btnDownloadScripts = document.getElementById("btn-download-scripts");
 		this._outText = document.getElementById("out-text");
 
 		this._iptFile.addEventListener("change", this._onChange_file.bind(this));
 		this._btnConvert.addEventListener("click", this._doConvert.bind(this));
 		this._btnCopy.addEventListener("click", this._pOnClick_btnCopy.bind(this));
+		this._btnDownloadScripts.addEventListener("click", this._pOnClick_btnDownloadScripts.bind(this));
+	}
+
+	static async _pInit_pState () {
+		const savedState = await localforage.getItem("state") || {};
+
+		this._iptText.value = savedState["ipt-text"] || "";
+		this._cbKeepSystem.checked = savedState["cb-keep-system"] || false;
+		this._cbKeepImg.checked = savedState["cb-keep-img"] || false;
+		this._iptScriptHeader.value = savedState["ipt-script-header"] || "";
+
+		this._btnConvert.addEventListener("click", () => {
+			localforage.setItem("state", {
+				"ipt-text": this._iptText.value,
+				"cb-keep-system": this._cbKeepSystem.checked,
+				"cb-keep-img": this._cbKeepImg.checked,
+				"ipt-script-header": this._iptScriptHeader.value,
+			});
+		});
+	}
+
+	static async pInit () {
+		this._pInit_elements();
+		await this._pInit_pState();
 	}
 }
 
@@ -103,36 +167,39 @@ class ConverterUtil {
 }
 
 class Converter {
-	static getConverted (json, {isKeepImg = false} = {}) {
-		if (json instanceof Array) {
-			const [, ...rest] = arguments;
-			return json
-				.sort((a, b) => (a.flags?.srd5e?.page || "").localeCompare(b.flags?.srd5e?.page || "")
-					|| a.type.localeCompare(b.type)
-					|| a.name.localeCompare(b.name, {sensitivity: "base"}))
-				.map(it => this.getConverted(it, ...rest));
-		}
+	static getConverted (json, {isKeepSystem = false, isKeepImg = false, scriptHeader = null} = {}) {
+		const name = json.name;
+		const source = this._getSource(json);
 
 		const effects = EffectConverter.getEffects(json);
-		const flags = FlagConverter.getFlags(json);
+		const {flags, script} = FlagConverter.getFlags({json, name, source, scriptHeader});
 
 		const out = {
-			name: json.name,
-			source: this._getSource(json),
+			name,
+			source,
 			effects,
 			flags,
 		};
+		if (script) out.itemMacro = {file: script.filename};
+
+		if (isKeepSystem && json.system) {
+			if (json.system.source) delete json.system.source;
+			if (Object.keys(json.system || {}).length) out.system = flattenObject(json.system);
+		}
 
 		if (isKeepImg) {
 			const img = ImgConverter.getImg(json);
 			if (img) out.img = img;
 		}
 
-		return out;
+		return {
+			data: out,
+			script,
+		};
 	}
 
 	static _getSource (json) {
-		const sourceRaw = json.data?.source;
+		const sourceRaw = json.system?.source;
 		if (!sourceRaw) return null;
 		return sourceRaw
 			.split(/[,;.]/g)[0]
@@ -142,10 +209,11 @@ class Converter {
 }
 
 class FlagConverter {
-	static getFlags (json) {
-		if (!Object.keys(json.flags || {}).length) return;
+	static getFlags ({json, name, source, scriptHeader = null}) {
+		if (!Object.keys(json.flags || {}).length) return {};
 
-		const out = {};
+		const outFlags = {};
+		let outScript = null;
 
 		Object.entries(json.flags)
 			.forEach(([k, flags]) => {
@@ -167,31 +235,74 @@ class FlagConverter {
 					case "midi-qol": {
 						const outSub = {};
 						ConverterUtil.copyTruthy(outSub, flags);
-						if (Object.keys(outSub).length) out[k] = outSub;
+						if (Object.keys(outSub).length) outFlags[k] = outSub;
 						break;
 					}
 					case "midiProperties": {
 						const outSub = {};
 						ConverterUtil.copyTruthy(outSub, flags);
-						if (Object.keys(outSub).length) out[k] = outSub;
+						if (Object.keys(outSub).length) outFlags[k] = outSub;
 						break;
 					}
 					case "enhanced-terrain-layer": {
 						const outSub = {};
 						ConverterUtil.copyTruthy(outSub, flags);
-						if (Object.keys(outSub).length) out[k] = outSub;
+						if (Object.keys(outSub).length) outFlags[k] = outSub;
+						break;
+					}
+					// endregion
+
+					// region Special handling for item macros
+					case "itemacro": {
+						const filename = getMacroFilename({name, source});
+
+						const lines = flags.macro.command
+							.trim()
+							.replace(/\r/g, "")
+							.split("\n");
+
+						// world's worst heuristic
+						const indentStyle = lines.some(it => it.startsWith("  "))
+							? "  "
+							: "\t";
+
+						const script = [
+							scriptHeader,
+							`async function macro (args) {`,
+							lines
+								.map(l => {
+									const lTrim = indentStyle === "  "
+										? l.replace(/^(?<spaces> {2}\s+)/g, (...m) => "\t".repeat(Math.floor(m.at(-1).spaces.length / 2)))
+										: l;
+									return `\t${lTrim}`;
+								})
+								.join("\n"),
+							`}\n`,
+						]
+							.filter(Boolean)
+							.join("\n");
+
+						if (outScript != null) throw new Error(`Multiple scripts found! This should never occur.`);
+						outScript = {
+							filename,
+							script,
+						};
+
 						break;
 					}
 					// endregion
 
 					default: {
 						console.warn(`Unknown flag property "${k}"--copying as-is`);
-						out[k] = flags;
+						outFlags[k] = flags;
 					}
 				}
 			});
 
-		if (Object.keys(out).length) return out;
+		const out = {};
+		if (Object.keys(outFlags).length) out.flags = outFlags;
+		if (outScript != null) out.script = outScript;
+		return out;
 	}
 }
 
@@ -222,6 +333,7 @@ class EffectConverter {
 	static _mutPreClean (eff) {
 		// N.b. "selectedKey" is midi-qol UI QoL tracking data, and can be safely skipped
 		["_id", "icon", "label", "origin", "tint", "selectedKey"].forEach(prop => delete eff[prop]);
+		["statuses"].filter(prop => !eff[prop].length).forEach(prop => delete eff[prop]);
 
 		// Delete these only if falsy--we only store `"true"` disabled/transfer values
 		["disabled", "transfer"].filter(prop => !eff[prop]).forEach(prop => delete eff[prop]);
@@ -352,4 +464,4 @@ class ImgConverter {
 	}
 }
 
-window.addEventListener("load", () => ConverterUi.init());
+window.addEventListener("load", () => ConverterUi.pInit());

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,8 @@
 	<title>Tools</title>
 
 	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+	<script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js" integrity="sha256-rMfkFFWoB2W1/Zx+4bgHim0WC7vKRVrq6FTeZclH1Z4=" crossorigin="anonymous"></script>
+	<script src="https://cdn.jsdelivr.net/npm/localforage@1.10.0/dist/localforage.min.js" integrity="sha256-zBaNlfuSfUaxBDcmz+E5mOCJAv9j8kMw4rsikBCe0UU=" crossorigin="anonymous"></script>
 
 	<style>
 		textarea.form-control {
@@ -19,6 +21,10 @@
 		.w-80p {
 			width: 80px !important;
 		}
+
+		.w-200p {
+			width: 200px !important;
+		}
 	</style>
 </head>
 <body class="vh-100 vw-100">
@@ -30,22 +36,33 @@
 			</div>
 			<textarea class="form-control h-100 min-h-0 lh-1 font-monospace" id="ipt-text"></textarea>
 		</div>
+
 		<div class="col-6 h-100 d-flex flex-column">
 			<div class="d-flex align-items-center mb-3">
+				<label class="me-2">
+					<span>Keep <code>system</code></span>
+					<input type="checkbox" id="cb-keep-system">
+				</label>
 				<label class="me-2">
 					<span>Keep <code>img</code>s</span>
 					<input type="checkbox" id="cb-keep-img">
 				</label>
+				<label class="flex-grow-1">
+					<span>Script Header</span>
+					<textarea class="form-control min-h-0 lh-1 font-monospace" id="ipt-script-header"></textarea>
+				</label>
+			</div>
 
-				<div class="vr me-2"></div>
-
+			<div class="d-flex align-items-center mb-3">
 				<button type="button" class="btn btn-primary btn-sm me-1 w-80p" id="btn-convert">Convert</button>
 				<button type="button" class="btn btn-primary btn-sm me-1 w-80p" id="btn-copy">Copy</button>
+				<button type="button" class="btn btn-primary btn-sm me-1 w-200p" id="btn-download-scripts" disabled>Download Scripts</button>
 			</div>
+
 			<textarea class="form-control h-100 min-h-0 lh-1 font-monospace" id="out-text"></textarea>
 		</div>
 	</div>
 </div>
 </body>
-<script type="text/javascript" src="client.js"></script>
+<script defer="" src="client.js" type="module"></script>
 </html>

--- a/docs/util.js
+++ b/docs/util.js
@@ -1,0 +1,17 @@
+export const doDownload = (filename, {blob, data, mimeType}) => {
+	if (blob && (data || mimeType)) throw new Error(`Either "blob" or "data" and "mimeType" must be specified!`);
+
+	blob = blob || new Blob([data], {type: mimeType});
+
+	const a = document.createElement("a");
+	a.href = window.URL.createObjectURL(blob);
+	a.download = filename;
+	a.dispatchEvent(new MouseEvent("click", {bubbles: true, cancelable: true, view: window}));
+	setTimeout(() => window.URL.revokeObjectURL(a.href), 100);
+};
+
+export const pDoDownloadZip = async (filename, fileMetas) => {
+	const zip = new JSZip();
+	fileMetas.forEach(({name, data}) => zip.file(name, data));
+	await doDownload(filename, {blob: await zip.generateAsync({type: "blob"})});
+};

--- a/license/ddb-importer.md
+++ b/license/ddb-importer.md
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2019 Sebastian Will
+Copyright (c) 2020 Jack Holloway
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/macro-item/spell/Generic_ddbi-aa-damage-on-entry.js
+++ b/macro-item/spell/Generic_ddbi-aa-damage-on-entry.js
@@ -1,0 +1,170 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	if (!game.modules.get("ActiveAuras")?.active) {
+		ui.notifications.error("ActiveAuras is not enabled");
+		return;
+	} else if (!game.modules.get("plutonium-addon-automation")?.active) {
+		ui.notifications.error("plutonium-addon-automation is not enabled");
+		return;
+	}
+
+	const lastArg = args[args.length - 1];
+
+	async function rollItemDamage (targetToken, itemUuid, itemLevel) {
+		const item = await fromUuid(itemUuid);
+		const caster = item.parent;
+		const ddbEffectFlags = item.flags["plutonium-addon-automation"].effect;
+		const isCantrip = ddbEffectFlags.isCantrip;
+		const damageDice = ddbEffectFlags.dice;
+		const damageType = ddbEffectFlags.damageType;
+		const saveAbility = ddbEffectFlags.save;
+		const casterToken = canvas.tokens.placeables.find((t) => t.actor?.uuid === caster.uuid);
+		const scalingDiceArray = item.system.scaling.formula.split("d");
+		const scalingDiceNumber = itemLevel - item.system.level;
+		const upscaledDamage = isCantrip
+			? `${game.modules.get("plutonium-addon-automation").api.DdbImporter.effects.getCantripDice(caster)}d${scalingDiceArray[1]}[${damageType}]`
+			: scalingDiceNumber > 0 ? `${scalingDiceNumber}d${scalingDiceArray[1]}[${damageType}] + ${damageDice}` : damageDice;
+
+		const workflowItemData = duplicate(item);
+		workflowItemData.system.target = {value: 1, units: "", type: "creature"};
+		workflowItemData.system.save.ability = saveAbility;
+		workflowItemData.system.components.concentration = false;
+		workflowItemData.system.level = itemLevel;
+		workflowItemData.system.duration = {value: null, units: "inst"};
+		workflowItemData.system.target = {value: null, width: null, units: "", type: "creature"};
+
+		setProperty(workflowItemData, "flags.itemacro", {});
+		setProperty(workflowItemData, "flags.midi-qol", {});
+		setProperty(workflowItemData, "flags.dae", {});
+		setProperty(workflowItemData, "effects", []);
+		delete workflowItemData._id;
+
+		const saveOnEntry = ddbEffectFlags.saveOnEntry;
+		// console.warn("saveOnEntry", {ddbEffectFlags, saveOnEntry});
+		if (saveOnEntry) {
+			// eslint-disable-next-line new-cap
+			const entryItem = new CONFIG.Item.documentClass(workflowItemData, {parent: caster});
+			// console.warn("Saving item on entry", {entryItem, targetToken});
+			const options = {
+				showFullCard: false,
+				createWorkflow: true,
+				targetUuids: [targetToken.document.uuid],
+				configureDialog: false,
+				versatile: false,
+				consumeResource: false,
+				consumeSlot: false,
+			};
+			await MidiQOL.completeItemUse(entryItem, {}, options);
+		} else {
+			const damageRoll = await new CONFIG.Dice.DamageRoll(upscaledDamage).evaluate({async: true});
+			if (game.dice3d) game.dice3d.showForRoll(damageRoll);
+
+			workflowItemData.name = `${workflowItemData.name}: Turn Entry Damage`;
+
+			await new MidiQOL.DamageOnlyWorkflow(
+				caster,
+				casterToken,
+				damageRoll.total,
+				damageType,
+				[targetToken],
+				damageRoll,
+				{
+					flavor: `(${CONFIG.DND5E.damageTypes[damageType]})`,
+					itemCardId: "new",
+					itemData: workflowItemData,
+					isCritical: false,
+				},
+			);
+		}
+	}
+
+	if (args[0].tag === "OnUse" && args[0].macroPass === "preActiveEffects") {
+		const safeName = lastArg.itemData.name.replace(/\s|'|\.|’/g, "_");
+		const dataTracker = {
+			randomId: randomID(),
+			targetUuids: lastArg.targetUuids,
+			startRound: game.combat.round,
+			startTurn: game.combat.turn,
+			spellLevel: lastArg.spellLevel,
+		};
+
+		const item = await fromUuid(lastArg.itemUuid);
+		await DAE.unsetFlag(item, `${safeName}Tracker`);
+		await DAE.setFlag(item, `${safeName}Tracker`, dataTracker);
+
+		const ddbEffectFlags = lastArg.item.flags["plutonium-addon-automation"]?.effect;
+
+		if (ddbEffectFlags) {
+			const sequencerFile = ddbEffectFlags.sequencerFile;
+			if (sequencerFile) {
+				const scale = ddbEffectFlags.sequencerScale ?? 1;
+				await game.modules.get("plutonium-addon-automation").api.DdbImporter.effects.attachSequencerFileToTemplate(lastArg.templateUuid, sequencerFile, lastArg.itemUuid, scale);
+			}
+			if (ddbEffectFlags.isCantrip) {
+				const cantripDice = game.modules.get("plutonium-addon-automation").api.DdbImporter.effects.getCantripDice(lastArg.actor);
+				args[0].spellLevel = cantripDice;
+				ddbEffectFlags.cantripDice = cantripDice;
+				let newEffects = args[0].item.effects.map((effect) => {
+					effect.changes = effect.changes.map((change) => {
+						change.value = change.value.replace("@cantripDice", cantripDice);
+						return change;
+					});
+					return effect;
+				});
+				args[0].item.effects = duplicate(newEffects);
+				args[0].itemData.effects = duplicate(newEffects);
+			}
+			const template = await fromUuid(lastArg.templateUuid);
+			await template.update({"flags.effect": ddbEffectFlags});
+		}
+
+		return game.modules.get("ActiveAuras").api.AAHelpers.applyTemplate(args);
+	} else if (args[0] === "on") {
+		const safeName = (lastArg.efData.name ?? lastArg.efData.label).replace(/\s|'|\.|’/g, "_");
+		const item = await fromUuid(lastArg.efData.origin);
+		const targetItemTracker = DAE.getFlag(item.parent, `${safeName}Tracker`);
+		const originalTarget = targetItemTracker.targetUuids.includes(lastArg.tokenUuid);
+		const target = canvas.tokens.get(lastArg.tokenId);
+		const targetTokenTrackerFlag = DAE.getFlag(target, `${safeName}Tracker`);
+		const targetedThisCombat = targetTokenTrackerFlag && targetItemTracker.randomId === targetTokenTrackerFlag.randomId;
+		const targetTokenTracker = targetedThisCombat
+			? targetTokenTrackerFlag
+			: {
+				randomId: targetItemTracker.randomId,
+				round: game.combat.round,
+				turn: game.combat.turn,
+				hasLeft: false,
+			};
+
+		const castTurn = targetItemTracker.startRound === game.combat.round && targetItemTracker.startTurn === game.combat.turn;
+		const isLaterTurn = game.combat.round > targetTokenTracker.round || game.combat.turn > targetTokenTracker.turn;
+
+		// if:
+		// not cast turn, and not part of the original target
+		// AND one of the following
+		// not original template and have not yet had this effect applied this combat OR
+		// has been targeted this combat, left and re-entered effect, and is a later turn
+		if (castTurn && originalTarget) {
+			console.debug(`Token ${target.name} is part of the original target for ${item.name}`);
+		} else if (!targetedThisCombat || (targetedThisCombat && targetTokenTracker.hasLeft && isLaterTurn)) {
+			console.debug(`Token ${target.name} is targeted for immediate damage with ${item.name}, using the following factors`, {originalTarget, castTurn, targetedThisCombat, targetTokenTracker, isLaterTurn});
+			targetTokenTracker.hasLeft = false;
+			await rollItemDamage(target, lastArg.efData.origin, targetItemTracker.spellLevel);
+		}
+		await DAE.setFlag(target, `${safeName}Tracker`, targetTokenTracker);
+	} else if (args[0] === "off") {
+		const safeName = (lastArg.efData.name ?? lastArg.efData.label).replace(/\s|'|\.|’/g, "_");
+		const target = canvas.tokens.get(lastArg.tokenId);
+		const targetTokenTracker = DAE.getFlag(target, `${safeName}Tracker`);
+
+		if (targetTokenTracker) {
+			targetTokenTracker.hasLeft = true;
+			targetTokenTracker.turn = game.combat.turn;
+			targetTokenTracker.round = game.combat.round;
+			await DAE.setFlag(target, `${safeName}Tracker`, targetTokenTracker);
+		}
+	}
+}

--- a/macro-item/spell/PHB_armor-of-agathys.js
+++ b/macro-item/spell/PHB_armor-of-agathys.js
@@ -1,0 +1,37 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	if (args.length !== 3 || args[0] !== "onUpdateActor") return;
+	const lastArg = args[2];
+	const spellLevel = args[1];
+	const message = game.messages.contents.findLast((i) =>
+		i.content.includes("<div class=\"dnd5e chat-card item-card midi-qol-item-card\""),
+	);
+	let workflow = MidiQOL.Workflow.getWorkflow(message.flags["midi-qol"].workflowId);
+	const validAttacks = ["mwak", "msak"];
+	if (
+		validAttacks.includes(workflow.item?.system?.actionType)
+		&& workflow.hitTargets?.has(lastArg.sourceToken)
+	) {
+		const attackerToken = workflow.token;
+		const damageAmount = parseInt(spellLevel) * 5;
+		const damageType = "cold";
+		const messageContent = `Armor of Agathys reactive damage: ${damageAmount} (${damageType})`;
+		await ChatMessage.create({content: messageContent});
+		console.log(attackerToken);
+		await MidiQOL.applyTokenDamage(
+			[{type: `${damageType}`, damage: damageAmount}],
+			damageAmount,
+			new Set([attackerToken]),
+			item,
+			new Set(),
+			{forceApply: false},
+		);
+	}
+	if (lastArg.updates.system.attributes.hp.temp <= 0) {
+		const effectId = lastArg.sourceActor.effects.find((eff) => (eff.name ?? eff.label) === "Armor of Agathys").id;
+		await MidiQOL.socket().executeAsGM("removeEffects", {actorUuid: lastArg.actorUuid, effects: [effectId]});
+	}
+}

--- a/macro-item/spell/PHB_aura-of-life.js
+++ b/macro-item/spell/PHB_aura-of-life.js
@@ -1,0 +1,17 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	if (!game.combat) return;
+	const lastArg = args[args.length - 1];
+
+	if (args[0] === "each") {
+		const targetActor = lastArg.actor;
+		if (targetActor.system.attributes.hp.value === 0) {
+			await targetActor.update({"system.attributes.hp.value": 1});
+			ui.notifications.info(`${targetActor.name} has been revived to 1 HP.`);
+			ChatMessage.create({content: `${targetActor.name} has been revived to 1 HP by Aura of Life.`});
+		}
+	}
+}

--- a/macro-item/spell/PHB_branding-smite.js
+++ b/macro-item/spell/PHB_branding-smite.js
@@ -1,0 +1,57 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	try {
+		if (!["mwak", "rwak"].includes(args[0].item.system.actionType)) return {};
+		if (args[0].hitTargetUuids.length === 0) return {}; // did not hit anyone
+		for (let tokenUuid of args[0].hitTargetUuids) {
+			const target = await fromUuid(tokenUuid);
+			const targetActor = target.actor;
+			if (!targetActor) continue;
+			// remove the invisible condition
+			const effect = targetActor?.effects.find((ef) => (ef.name ?? ef.label) === game.i18n.localize("midi-qol.invisible"));
+			if (effect) { await MidiQOL.socket().executeAsGM("removeEffects", {actorUuid: targetActor.uuid, effects: [effect.id]}); }
+			// create the dim light effect on the target
+			let bsEffect = new ActiveEffect({
+				label: "Branding Smite",
+				name: "Branding Smite",
+				icon: "icons/magic/fire/dagger-rune-enchant-flame-strong-purple.webp",
+				changes: [
+					{
+						value: 5,
+						mode: CONST.ACTIVE_EFFECT_MODES.UPGRADE,
+						priority: 20,
+						key: "ATL.light.dim",
+					},
+				],
+				duration: {seconds: 60},
+			});
+			// 60 seconds is wrong - should look for the branding smite effect and use the remaining duration - but hey
+
+			await MidiQOL.socket().executeAsGM("createEffects", {
+				actorUuid: targetActor.uuid,
+				effects: [bsEffect.toObject()],
+			});
+		}
+		Hooks.once("midi-qol.RollComplete", (workflow) => {
+			console.log("Deleting concentration");
+			const effect = MidiQOL.getConcentrationEffect(actor);
+			if (effect) effect.delete();
+			return true;
+		});
+		const spellLevel = actor.flags["midi-qol"].brandingSmite.level;
+		const workflow = args[0].workflow;
+		const rollOptions = {
+			critical: workflow.isCritical,
+			criticalMultiplier: workflow.damageRoll?.options?.criticalMultiplier,
+			powerfulCritical: workflow.damageRoll?.options?.powerfulCritical,
+			multiplyNumeric: workflow.damageRoll?.options?.multiplyNumeric,
+		};
+		const damageFormula = new CONFIG.Dice.DamageRoll(`${spellLevel}d6[radiant]`, {}, rollOptions);
+		return {damageRoll: damageFormula.formula, flavor: "Branding Smite"};
+	} catch (err) {
+		console.error(`${args[0].itemData.name} - Branding Smite`, err);
+	}
+}

--- a/macro-item/spell/PHB_chromatic-orb.js
+++ b/macro-item/spell/PHB_chromatic-orb.js
@@ -1,0 +1,90 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	const lastArg = args[args.length - 1];
+
+	async function selectDamage () {
+		const damageTypes = {
+			acid: "icons/magic/acid/dissolve-bone-white.webp",
+			cold: "icons/magic/water/barrier-ice-crystal-wall-jagged-blue.webp",
+			fire: "icons/magic/fire/barrier-wall-flame-ring-yellow.webp",
+			lightning: "icons/magic/lightning/bolt-strike-blue.webp",
+			poison: "icons/consumables/potions/bottle-conical-fumes-green.webp",
+			thunder: "icons/magic/sonic/explosion-shock-wave-teal.webp",
+		};
+		function generateEnergyBox (type) {
+			return `
+	<label class="radio-label">
+		<input type="radio" name="type" value="${type}" />
+		<img src="${damageTypes[type]}" style="border: 0px; width: 50px; height: 50px"/>
+		${type.charAt(0).toUpperCase() + type.slice(1)}
+	</label>
+	`;
+		}
+		const damageSelection = Object.keys(damageTypes).map((type) => generateEnergyBox(type)).join("\n");
+		const content = `
+	<style>
+		.chromOrb .form-group {
+			display: flex;
+			flex-wrap: wrap;
+			width: 100%;
+			align-items: flex-start;
+		}
+		.chromOrb .radio-label {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			text-align: center;
+			justify-items: center;
+			flex: 1 0 20%;
+			line-height: normal;
+		}
+		.chromOrb .radio-label input {
+			display: none;
+		}
+		.chromOrb img {
+			border: 0px;
+			width: 50px;
+			height: 50px;
+			flex: 0 0 50px;
+			cursor: pointer;
+		}
+		/* CHECKED STYLES */
+		.chromOrb [type="radio"]:checked + img {
+			outline: 2px solid #f00;
+		}
+	</style>
+	<form class="chromOrb">
+		<div class="form-group" id="types">
+			${damageSelection}
+		</div>
+	</form>
+	`;
+		const damageType = await new Promise((resolve) => {
+			new Dialog({
+				title: "Choose a damage type",
+				content,
+				buttons: {
+					ok: {
+						label: "Choose!",
+						callback: async (html) => {
+							const element = html.find("input[type='radio'][name='type']:checked").val();
+							resolve(element);
+						},
+					},
+				},
+			}).render(true);
+		});
+		return damageType;
+	}
+	const damageType = await selectDamage();
+	if (!damageType) return;
+
+	const workflow = lastArg.workflow;
+	const newDamageRoll = workflow.damageRoll;
+	newDamageRoll._formula += `[${damageType}]`;
+	workflow.defaultDamageType = damageType;
+	await workflow.setDamageRoll(newDamageRoll);
+}

--- a/macro-item/spell/PHB_color-spray.js
+++ b/macro-item/spell/PHB_color-spray.js
@@ -1,0 +1,62 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	// based on @ccjmk and @crymic macro for sleep.
+	// uses convinient effects
+	// Midi-qol "On Use"
+
+	async function wait (ms) {
+		return new Promise((resolve) => {
+			setTimeout(resolve, ms);
+		});
+	}
+
+	const blindHp = await args[0].damageTotal;
+	const immuneConditions = [game.i18n.localize("Blinded"), game.i18n.localize("Unconscious")];
+	console.log(`Color Spray Spell => Available HP Pool [${blindHp}] points`);
+	const targets = await args[0].targets
+		.filter((i) => i.actor.system.attributes.hp.value !== 0 && !i.actor.effects.find((x) => immuneConditions.includes((x.name ?? x.label))))
+		.sort((a, b) => (canvas.tokens.get(a.id).actor.system.attributes.hp.value < canvas.tokens.get(b.id).actor.system.attributes.hp.value ? -1 : 1));
+	let remainingBlindHp = blindHp;
+	let blindTarget = [];
+
+	for (let target of targets) {
+		const findTarget = await canvas.tokens.get(target.id);
+		const targetHpValue = findTarget.actor.system.attributes.hp.value;
+		const targetImg = target?.texture?.src;
+
+		if (remainingBlindHp >= targetHpValue) {
+			remainingBlindHp -= targetHpValue;
+			console.log(`Color Spray Results => Target: ${findTarget.name} |	HP: ${targetHpValue} | HP Pool: ${remainingBlindHp} | Status: Blinded`);
+			blindTarget.push(`<div class="midi-qol-flex-container"><div>Blinded</div><div class="midi-qol-target-npc midi-qol-target-name" id="${findTarget.id}"> ${findTarget.name}</div><div><img src="${targetImg}" width="30" height="30" style="border:0px"></div></div>`);
+			const gameRound = game.combat ? game.combat.round : 0;
+			const effectData = {
+				label: "Color Spray: Blinded",
+				name: "Color Spray: Blinded",
+				icon: args[0].itemData.img,
+				origin: args[0].uuid,
+				disabled: false,
+				duration: {startRound: gameRound, startTime: game.time.worldTime},
+				flags: {dae: {specialDuration: ["turnEndSource"]}},
+				changes: [
+					{key: "macro.CE", mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM, value: game.i18n.localize("Blinded"), priority: 20},
+				],
+			};
+
+			await MidiQOL.socket().executeAsGM("createEffects", {actorUuid: findTarget.actor.uuid, effects: [effectData]});
+		} else {
+			console.log(`Color Spray Results => Target: ${target.name} | HP: ${targetHpValue} | HP Pool: ${remainingBlindHp - targetHpValue} | Status: Not enough HP remaining`);
+			blindTarget.push(`<div class="midi-qol-flex-container"><div>misses</div><div class="midi-qol-target-npc midi-qol-target-name" id="${findTarget.id}"> ${findTarget.name}</div><div><img src="${targetImg}" width="30" height="30" style="border:0px"></div></div>`);
+		}
+	}
+	await wait(500);
+	const blindResults = `<div><div class="midi-qol-nobox">${blindTarget.join("")}</div></div>`;
+	const chatMessage = game.messages.get(args[0].itemCardId);
+	let content = duplicate(chatMessage.content);
+	const searchString = /<div class="midi-qol-hits-display">[\s\S]*<div class="end-midi-qol-hits-display">/g;
+	const replaceString = `<div class="midi-qol-hits-display"><div class="end-midi-qol-hits-display">${blindResults}`;
+	content = await content.replace(searchString, replaceString);
+	await chatMessage.update({content: content});
+}

--- a/macro-item/spell/PHB_elemental-weapon.js
+++ b/macro-item/spell/PHB_elemental-weapon.js
@@ -1,0 +1,198 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	const lastArg = args[args.length - 1];
+	const tokenOrActor = await fromUuid(lastArg.actorUuid);
+	const targetActor = tokenOrActor.actor ? tokenOrActor.actor : tokenOrActor;
+
+	function valueLimit (val, min, max) {
+		return val < min ? min : val > max ? max : val;
+	}
+
+	async function selectDamage () {
+		const damageTypes = {
+			acid: "icons/magic/acid/dissolve-bone-white.webp",
+			cold: "icons/magic/water/barrier-ice-crystal-wall-jagged-blue.webp",
+			fire: "icons/magic/fire/barrier-wall-flame-ring-yellow.webp",
+			lightning: "icons/magic/lightning/bolt-strike-blue.webp",
+			thunder: "icons/magic/sonic/explosion-shock-wave-teal.webp",
+		};
+		function generateEnergyBox (type) {
+			return `
+	<label class="radio-label">
+		<input type="radio" name="type" value="${type}" />
+		<img src="${damageTypes[type]}" style="border: 0px; width: 50px; height: 50px"/>
+		${type.charAt(0).toUpperCase() + type.slice(1)}
+	</label>
+	`;
+		}
+		const damageSelection = Object.keys(damageTypes).map((type) => generateEnergyBox(type)).join("\n");
+		const content = `
+	<style>
+		.chromOrb .form-group {
+			display: flex;
+			flex-wrap: wrap;
+			width: 100%;
+			align-items: flex-start;
+		}
+		.chromOrb .radio-label {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			text-align: center;
+			justify-items: center;
+			flex: 1 0 20%;
+			line-height: normal;
+		}
+		.chromOrb .radio-label input {
+			display: none;
+		}
+		.chromOrb img {
+			border: 0px;
+			width: 50px;
+			height: 50px;
+			flex: 0 0 50px;
+			cursor: pointer;
+		}
+		/* CHECKED STYLES */
+		.chromOrb [type="radio"]:checked + img {
+			outline: 2px solid #f00;
+		}
+	</style>
+	<form class="chromOrb">
+		<div class="form-group" id="types">
+			${damageSelection}
+		</div>
+	</form>
+	`;
+		const damageType = await new Promise((resolve) => {
+			new Dialog({
+				title: "Choose a damage type",
+				content,
+				buttons: {
+					ok: {
+						label: "Choose!",
+						callback: async (html) => {
+							const element = html.find("input[type='radio'][name='type']:checked").val();
+							resolve(element);
+						},
+					},
+				},
+			}).render(true);
+		});
+		return damageType;
+	}
+
+	/**
+	 * Select for weapon and apply bonus based on spell level
+	 */
+	if (args[0] === "on") {
+		const weapons = targetActor.items.filter((i) => i.type === "weapon" && !i.system.properties.mgc);
+		let weaponContent = "";
+
+		// Filter for weapons
+		weapons.forEach((weapon) => {
+			weaponContent += `<label class="radio-label">
+		<input type="radio" name="weapon" value="${weapon.id}">
+		<img src="${weapon.img}" style="border:0px; width: 50px; height:50px;">
+		${weapon.name}
+	</label>`;
+		});
+
+		let content = `
+			<style>
+			.magicWeapon .form-group {
+					display: flex;
+					flex-wrap: wrap;
+					width: 100%;
+					align-items: flex-start;
+				}
+	
+				.magicWeapon .radio-label {
+					display: flex;
+					flex-direction: column;
+					align-items: center;
+					text-align: center;
+					justify-items: center;
+					flex: 1 0 25%;
+					line-height: normal;
+				}
+	
+				.magicWeapon .radio-label input {
+					display: none;
+				}
+	
+				.magicWeapon img {
+					border: 0px;
+					width: 50px;
+					height: 50px;
+					flex: 0 0 50px;
+					cursor: pointer;
+				}
+	
+				/* CHECKED STYLES */
+				.magicWeapon [type=radio]:checked + img {
+					outline: 2px solid #f00;
+				}
+			</style>
+			<form class="magicWeapon">
+				<div class="form-group" id="weapons">
+						${weaponContent}
+				</div>
+			</form>
+	`;
+
+		new Dialog({
+			content,
+			buttons: {
+				ok: {
+					label: `Ok`,
+					callback: async () => {
+						const itemId = $("input[type='radio'][name='weapon']:checked").val();
+						const weaponItem = targetActor.items.get(itemId);
+						let copyItem = duplicate(weaponItem);
+						const spellLevel = Math.floor(args[1] / 2);
+						const bonus = valueLimit(spellLevel, 1, 3);
+						const wpDamage = copyItem.system.damage.parts[0][0];
+						const verDamage = copyItem.system.damage.versatile;
+						DAE.setFlag(targetActor, "magicWeapon", {
+							name: weaponItem.name,
+							attackBonus: weaponItem.system.attackBonus,
+							weapon: itemId,
+							damage: weaponItem.system.damage,
+							mgc: copyItem.system.properties.mgc,
+						});
+						copyItem.name = `${weaponItem.name} (Elemental Weapon)`;
+						if (copyItem.system.attackBonus === "") copyItem.system.attackBonus = "0";
+						copyItem.system.attackBonus = `${parseInt(copyItem.system.attackBonus) + bonus}`;
+						copyItem.system.damage.parts[0][0] = `${wpDamage} + ${bonus}`;
+						copyItem.system.properties.mgc = true;
+						if (verDamage !== "" && verDamage !== null) copyItem.system.damage.versatile = `${verDamage} + ${bonus}`;
+
+						const damageType = await selectDamage();
+						copyItem.system.damage.parts.push([`${bonus}d4[${damageType}]`, damageType]);
+						targetActor.updateEmbeddedDocuments("Item", [copyItem]);
+					},
+				},
+				cancel: {
+					label: `Cancel`,
+				},
+			},
+		}).render(true);
+	}
+
+	// Revert weapon and unset flag.
+	if (args[0] === "off") {
+		const {name, attackBonus, weapon, damage, mgc} = DAE.getFlag(targetActor, "magicWeapon");
+		const weaponItem = targetActor.items.get(weapon);
+		let copyItem = duplicate(weaponItem);
+		copyItem.name = name;
+		copyItem.system.attackBonus = attackBonus;
+		copyItem.system.damage = damage;
+		copyItem.system.properties.mgc = mgc;
+		targetActor.updateEmbeddedDocuments("Item", [copyItem]);
+		DAE.unsetFlag(targetActor, "magicWeapon");
+	}
+}

--- a/macro-item/spell/PHB_ensnaring-strike.js
+++ b/macro-item/spell/PHB_ensnaring-strike.js
@@ -1,0 +1,186 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	// Based on a macro by Elwin#1410 with permission. Thanks Elwin!
+	//
+	// Optional AA setup:
+	//	 A special custom restrained condition can be added for Ensnaring Strike.
+	//		 - In the AA Auto Rec menu, select the Active Effects tab.
+	//		 - Duplicate the Restrained entry.
+	//		 - Rename the duplicate to "Restrained [Ensnaring Strike]"
+	//		 - Change the animation to something more appropriate for the spell, e.g.:
+	//			 - Type: Spell
+	//			 - Animation: Entangle
+	//			 - Variant: 01
+	//			 - Color: Green
+
+	if (args[0].tag === "OnUse" && ["preTargeting"].includes(args[0].macroPass)) {
+		args[0].workflow.item.system["target"]["type"] = "self";
+		return;
+	}
+
+	const itemName = "Ensnaring Strike";
+	const icon = "icons/magic/nature/root-vine-entangled-hand.webp";
+
+	/**
+	 * Returns a temporary spell item data for the Ensnaring Strike effect.
+	 *
+	 * @param {*} sourceActor the actor that casted the origin spell item.
+	 * @param {*} originItem the origin spell item that was cast.
+	 * @param {*} originEffect the effect from the origin spell item that was cast.
+	 * @returns temporary spell item data for Ensnaring Strike effect.
+	 */
+	function getTempSpellData (sourceActor, originItem, originEffect) {
+		const level = getProperty(originEffect, "flags.midi-qol.castData.castLevel") ?? 1;
+		const nbDice = level;
+
+		// Get restrained condition id
+		const statusId = CONFIG.statusEffects.find(se => (se.name ?? se.label) === CONFIG.DND5E.conditionTypes["restrained"])?.id;
+		const conEffect = MidiQOL.getConcentrationEffect(sourceActor);
+
+		// Temporary spell data for the ensnaring effect.
+		// Note: we keep same id as origin spell to make sure that the AEs have the same origin
+		// as the origin spell (for concentration handling)
+		return {
+			_id: originItem.id,
+			type: "spell",
+			name: `${originItem.name}`,
+			img: originItem.img,
+			system: {
+				level: level,
+				actionType: "save",
+				save: {ability: "str"},
+				preparation: {mode: "atwill"},
+				target: {type: "creature", value: 1},
+			},
+			effects: [
+				{
+					_id: randomID(),
+					changes: [
+						{
+							key: "StatusEffect",
+							mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+							value: statusId,
+							priority: 20,
+						},
+						{
+							key: "flags.dae.deleteUuid",
+							mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+							value: conEffect.uuid,
+							priority: 20,
+						},
+						{
+							key: "flags.midi-qol.OverTime",
+							mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+							value: `turn=start,damageRoll=${nbDice}d6,damageType=piercing,label=${originItem.name}: Effect,actionSave=true,rollType=check,saveAbility=str,saveDC=@attributes.spelldc,killAnim=true`,
+							priority: 20,
+						},
+					],
+					origin: originItem.uuid,
+					disabled: false,
+					transfer: false,
+					icon,
+					label: originItem.name,
+					name: originItem.name,
+					duration: game.modules.get("plutonium-addon-automation")?.api.DdbImporter.effects.getRemainingDuration(conEffect.duration),
+				},
+			],
+		};
+	}
+
+	if (args[0].tag === "OnUse" && args[0].macroPass === "postActiveEffects") {
+		const macroData = args[0];
+
+		const workflow = MidiQOL.Workflow.getWorkflow(macroData.uuid);
+		if (workflow?.options?.skipOnUse) {
+			// Skip onUse when temporary effect item is used (this is a custom option that is passed to completeItemUse)
+			return;
+		}
+
+		if (macroData.hitTargets.length < 1) {
+			// No target hit
+			return;
+		}
+		if (!["mwak", "rwak"].includes(macroData.itemData.system.actionType)) {
+			// Not a weapon attack
+			return;
+		}
+
+		const originItem = await fromUuid(macroData.sourceItemUuid);
+		if (!originItem) {
+			// Could not find origin item
+			console.error(`${itemName}: origin item ${macroData.sourceItemUuid} not found.`);
+			return;
+		}
+		const sourceActor = await fromUuid(macroData.actorUuid);
+		if (sourceActor.getFlag("world", "ensnaring-strike.used")) {
+			// Effect already applied to target
+			console.warn(`${itemName}: spell already used.`);
+			return;
+		}
+
+		const originEffect = sourceActor.effects.find((ef) =>
+			ef.getFlag("midi-qol", "castData.itemUuid") === macroData.sourceItemUuid,
+		);
+		if (!originEffect) {
+			console.error(`${itemName}: spell active effect was not found.`);
+			return;
+		}
+
+		// Flag the spell as used.
+		let originEffectChanges = duplicate(originEffect.changes);
+		originEffectChanges.push({
+			key: "flags.world.ensnaring-strike.used",
+			mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+			value: "1",
+			priority: 20,
+		});
+		await originEffect.update({changes: originEffectChanges});
+
+		// Temporary spell data for the ensnaring effect
+		const spellData = getTempSpellData(sourceActor, originItem, originEffect);
+		// eslint-disable-next-line new-cap
+		const spell = new Item.implementation(spellData, {
+			parent: sourceActor,
+			temporary: true,
+		});
+
+		// If AA has a special custom effect for the restrained condition, use it instead of standard one
+		if (game.modules.get("autoanimations")?.active) {
+			game.modules.get("plutonium-addon-automation")?.api.DdbImporter.effects.configureCustomAAForCondition("restrained", macroData, originItem.name, spell.uuid);
+		}
+		// Check if target is large or larger and give it advantage on next save
+		const targetActor = macroData.hitTargets[0].actor;
+		if (dnd5e.config.tokenSizes[targetActor?.system.traits.size ?? "med"] >= dnd5e.config.tokenSizes["lg"]) {
+			await game.modules.get("plutonium-addon-automation")?.api.DdbImporter.effects.addSaveAdvantageToTarget(targetActor, originItem, "str", " (Large Creature)");
+		}
+		const options = {
+			createWorkflow: true,
+			targetUuids: [macroData.hitTargetUuids[0]],
+			configureDialog: false,
+			skipOnUse: true,
+		};
+		const spellEffectWorkflow = await MidiQOL.completeItemUse(spell, {}, options);
+		const conEffect = MidiQOL.getConcentrationEffect(sourceActor);
+
+		if (spellEffectWorkflow.hitTargets.size > 0 && spellEffectWorkflow.failedSaves.size > 0) {
+			// Transfer target of concentration from the caster to the target to allow removing effect on caster.
+			const conTargets = [];
+			spellEffectWorkflow.failedSaves.forEach((token) =>
+				conTargets.push({
+					tokenUuid: token.document?.uuid ?? token.uuid,
+					actorUuid: token.actor?.uuid ?? "",
+				}),
+			);
+			await sourceActor.setFlag("midi-qol", "concentration-data.targets", conTargets);
+			await originEffect.delete();
+		} else {
+			// Remove concentration and the effect causing it since the effect has been used
+			if (conEffect) {
+				conEffect.delete();
+			}
+		}
+	}
+}

--- a/macro-item/spell/PHB_hail-of-thorns.js
+++ b/macro-item/spell/PHB_hail-of-thorns.js
@@ -1,0 +1,143 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	// Based on a macro provided by the delightful @Elwin#1410
+
+	// Default name of the item
+	const defaultItemName = "Hail of Thorns";
+	// Set to false to remove debug logging
+	const debug = false;
+
+	const dependencies = ["dae", "itemacro", "times-up", "midi-qol"];
+	if (!game.modules.get("plutonium-addon-automation")?.api.DdbImporter.effects.requirementsSatisfied(defaultItemName, dependencies)) {
+		return;
+	}
+
+	if (debug) {
+		console.error(defaultItemName, args);
+	}
+
+	if (args[0].tag === "OnUse" && args[0].macroPass === "postActiveEffects") {
+		const macroData = args[0];
+
+		if (macroData.hitTargets.length < 1) {
+			// No target hit
+			return;
+		}
+		const rangedWeaponAttack = game.modules.get("plutonium-addon-automation")?.api.DdbImporter.effects.isRangedWeaponAttack(macroData);
+		if (!rangedWeaponAttack) {
+			// Not a ranged weapon attack
+			return;
+		}
+		const sourceItem = fromUuidSync(macroData.sourceItemUuid);
+		const itemName = sourceItem?.name ?? defaultItemName;
+
+		const originEffect = macroData.actor.effects.find(
+			(ef) => ef.getFlag("midi-qol", "castData.itemUuid") === macroData.sourceItemUuid,
+		);
+		if (!originEffect) {
+			console.error(`${defaultItemName}: spell active effect was not found.`);
+			return;
+		}
+		const level = getProperty(originEffect, "flags.midi-qol.castData.castLevel") ?? 1;
+		const nbDice = Math.min(level, 6);
+
+		// Temporary spell data for the burst effect
+		const areaSpellData = {
+			type: "spell",
+			name: `${itemName}: Burst`,
+			img: sourceItem?.img,
+			system: {
+				level: level,
+				target: {type: "sphere"},
+				chatFlavor: `[${nbDice}d10 - piercing] Target of the attack and each creature within 5 feet of it`,
+				damage: {parts: [[`${nbDice}d10[piercing]`, "piercing"]], versatile: ""},
+				actionType: "save",
+				save: {ability: "dex"},
+				preparation: {mode: "atwill"},
+				duration: {units: "inst"},
+			},
+		};
+		setProperty(
+			areaSpellData,
+			"flags.midi-qol.onUseMacroName",
+			`[preItemRoll]ItemMacro.${macroData.sourceItemUuid},[preambleComplete]ItemMacro.${macroData.sourceItemUuid},[preActiveEffects]ItemMacro.${macroData.sourceItemUuid}`,
+		);
+
+		// eslint-disable-next-line new-cap
+		const areaSpell = new CONFIG.Item.documentClass(areaSpellData, {
+			parent: macroData.actor,
+			temporary: true,
+		});
+
+		const options = {
+			createWorkflow: true,
+			targetUuids: macroData.hitTargetUuids,
+			configureDialog: false,
+		};
+		await MidiQOL.completeItemUse(areaSpell, {}, options);
+
+		// Remove concentration and the effect causing it since the effect has been used
+		const effect = MidiQOL.getConcentrationEffect(macroData.actor);
+		if (effect) {
+			await effect.delete();
+		}
+	} else if (args[0].tag === "OnUse" && args[0].macroPass === "preItemRoll") {
+		const macroData = args[0];
+
+		// Disable template creation, created and placed automatically in dnd5e.useItem hook.
+		macroData.workflow.config.createMeasuredTemplate = false;
+		Hooks.once("dnd5e.useItem", async function (item, config, options, templates) {
+			if (item.name !== macroData.item.name) {
+				return;
+			}
+			const effectRange = 5;
+			const targetToken = macroData.targets[0].object;
+			const circleRadius = (targetToken.document.width / 2) * 5 + effectRange;
+			const templateData = {
+				t: "circle",
+				user: game.user.id,
+				x: targetToken.center.x,
+				y: targetToken.center.y,
+				direction: 0,
+				distance: circleRadius,
+				borderColor: game.user.color,
+			};
+			// Note: set flag for walled templates if module enabled
+			if (game.modules.get("walledtemplates")?.active) {
+				setProperty(templateData, "flags.walledtemplates", {wallsBlock: "walled", wallRestriction: "move"});
+			}
+			// Note: this flag is set to allow AA to trigger if a template config exists for 'Hail of Thorns'
+			setProperty(templateData, "flags.dnd5e.origin", macroData.sourceItemUuid);
+
+			const [measuredTemplateDoc] = await canvas.scene.createEmbeddedDocuments("MeasuredTemplate", [templateData]);
+			if (!measuredTemplateDoc) {
+				console.error(`${defaultItemName} | Error could not create template`, templateData);
+			}
+		});
+		return true;
+	} else if (args[0].tag === "OnUse" && args[0].macroPass === "preambleComplete") {
+		const macroData = args[0];
+		// Add template to concentration data to be auto deleted
+		const concentrationData = macroData.actor.getFlag("midi-qol", "concentration-data");
+		if (concentrationData) {
+			const templatesToDelete = concentrationData.templates ? duplicate(concentrationData.templates) : [];
+			templatesToDelete.push(macroData.workflow.templateUuid);
+			await macroData.actor.setFlag("midi-qol", "concentration-data.templates", templatesToDelete);
+		}
+
+		// Select targets
+		const effectRange = 5;
+		const targetToken = macroData.targets[0].object;
+		const aoeTargets = game.modules.get("plutonium-addon-automation")?.api.DdbImporter.effects.selectTargetsWithinX(targetToken, effectRange, true);
+		if (debug) {
+			console.log(`${defaultItemName} | Burst targets`, aoeTargets);
+		}
+	} else if (args[0].tag === "OnUse" && args[0].macroPass === "preActiveEffects") {
+		const macroData = args[0];
+		// Note: update workflow to prevent adding effect to delete template, already handled by concentration-data
+		macroData.workflow.templateUuid = undefined;
+	}
+}

--- a/macro-item/spell/PHB_hex.js
+++ b/macro-item/spell/PHB_hex.js
@@ -1,0 +1,49 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	// onUse macro
+	if (args[0].hitTargets.length === 0) return;
+	if (args[0].tag === "OnUse") {
+		const targetUuid = args[0].hitTargets[0].uuid;
+		const tokenOrActor = await fromUuid(args[0].actorUuid);
+		const caster = tokenOrActor.actor ? tokenOrActor.actor : tokenOrActor;
+
+		if (!caster || !targetUuid) {
+			ui.notifications.warn("Hex: no token/target selected");
+			console.error("Hex: no token/target selected");
+			return;
+		}
+
+		const effectData = {
+			changes: [
+				{
+					key: "flags.midi-qol.hex",
+					mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+					value: targetUuid,
+					priority: 20,
+				}, // who is marked
+				{
+					key: "flags.dnd5e.DamageBonusMacro",
+					mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+					value: `ItemMacro.${args[0].item.name}`,
+					priority: 20,
+				}, // macro to apply the damage
+			],
+			origin: args[0].uuid, // flag the effect as associated to the spell being cast
+			disabled: false,
+			duration: args[0].item.effects[0].duration,
+			icon: args[0].item.img,
+			label: args[0].item.name,
+			name: args[0].item.name,
+		};
+		effectData.duration.startTime = game.time.worldTime;
+		await caster.createEmbeddedDocuments("ActiveEffect", [effectData]);
+	} else if (args[0].tag === "DamageBonus") {
+		const targetUuid = args[0].hitTargets[0].uuid;
+		if (targetUuid !== getProperty(args[0].actor.flags, "midi-qol.hex")) return {};
+		const diceMult = args[0].isCritical ? 2 : 1;
+		return {damageRoll: `${diceMult}d6[necrotic]`, flavor: "Hex Damage"};
+	}
+}

--- a/macro-item/spell/PHB_hunter's-mark.js
+++ b/macro-item/spell/PHB_hunter's-mark.js
@@ -1,0 +1,67 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	try {
+		const act = args[0].actor ?? actor;
+		if (args[0].macroPass === "DamageBonus") {
+			if (hasProperty(act, "flags.dae.onUpdateTarget") && args[0].hitTargets.length > 0) {
+				const isMarked = act.flags.dae.onUpdateTarget.some(
+					(flag) =>
+						flag.flagName === "Hunter's Mark"
+						&& flag.sourceTokenUuid === args[0].hitTargetUuids[0],
+				);
+				if (isMarked) {
+					let damageType = args[0].item.system.damage.parts[0][1];
+					const diceMult = args[0].isCritical ? 2 : 1;
+					return {
+						damageRoll: `${diceMult}d6[${damageType}]`,
+						flavor: "Hunter's Mark Damage",
+					};
+				}
+			} else {
+				return {};
+			}
+		} else if (args[0].macroPass === "preItemRoll") {
+			// check if we are already marking and if the marked target is dead.
+			const markedTarget = act.flags.dae.onUpdateTarget.find(
+				(flag) => flag.flagName === "Hunter's Mark",
+			)?.sourceTokenUuid;
+			if (markedTarget) {
+				const target = await fromUuid(markedTarget);
+				if (!target || target.actor.system.attributes.hp.value <= 0) {
+					// marked target is dead or removed so don't consume a resource
+					const currentDuration = duplicate(
+						act.effects.find(
+							(ef) => (ef.name ?? ef.label) === game.i18n.localize("midi-qol.Concentrating"),
+						).duration,
+					);
+					const useHookId = Hooks.on(
+						"dnd5e.preUseItem",
+						(hookItem, config, options) => {
+							if (hookItem !== item) return;
+							options.configureDialog = false;
+							config.consumeSpellLevel = false;
+							Hooks.off("dnd5e.preUseItem", useHookId);
+						},
+					);
+					const effectHookId = Hooks.on(
+						"preCreateActiveEffect",
+						(effect, data, options, user) => {
+							if ((effect.name ?? effect.label) === game.i18n.localize("midi-qol.Concentrating")) {
+								effect.updateSource({duration: currentDuration});
+								Hooks.off("dnd5e.preCreateActiveEffect", effectHookId);
+							}
+							return true;
+						},
+					);
+				}
+			}
+			return true;
+		}
+	} catch (err) {
+		console.error(`${args[0].itemData.name} - Hunter's Mark`, err);
+		return {};
+	}
+}

--- a/macro-item/spell/PHB_otto's-irresistible-dance.js
+++ b/macro-item/spell/PHB_otto's-irresistible-dance.js
@@ -1,0 +1,39 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	const lastArg = args[args.length - 1];
+
+	// DAE Macro Execute, Effect Value = "Macro Name"
+	const tokenOrActor = await fromUuid(lastArg.actorUuid);
+	const targetActor = tokenOrActor.actor ? tokenOrActor.actor : tokenOrActor;
+
+	const DAEItem = lastArg.efData.flags.dae.itemData;
+	const saveData = DAEItem.system.save;
+	const saveDC = (saveData.dc === null || saveData.dc === "") && saveData.scaling === "spell"
+		? (await fromUuid(lastArg.efData.origin)).parent.getRollData().attributes.spelldc
+		: saveData.dc;
+
+	if (args[0] === "each") {
+		new Dialog({
+			title: "Use action to make a wisdom save to end Irresistible Dance?",
+			buttons: {
+				one: {
+					label: "Yes",
+					callback: async () => {
+						const flavor = `${CONFIG.DND5E.abilities[saveData.ability].label} DC${saveDC} ${DAEItem?.name || ""}`;
+						const saveRoll = (await targetActor.rollAbilitySave(saveData.ability, {flavor})).total;
+
+						if (saveRoll >= saveDC) {
+							targetActor.deleteEmbeddedDocuments("ActiveEffect", [lastArg.effectId]);
+						} else if (saveRoll < saveDC) ChatMessage.create({content: `${targetActor.name} fails the save`});
+					},
+				},
+				two: {
+					label: "No",
+				},
+			},
+		}).render(true);
+	}
+}

--- a/macro-item/spell/PHB_silence.js
+++ b/macro-item/spell/PHB_silence.js
@@ -1,0 +1,14 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	if (!game.modules.get("ActiveAuras")?.active) {
+		ui.notifications.error("ActiveAuras is not enabled");
+		return;
+	}
+
+	if (args[0].macroPass === "preActiveEffects" || args[0].tag === "OnUse") {
+		return game.modules.get("ActiveAuras").api.AAHelpers.applyTemplate(args);
+	}
+}

--- a/macro-item/spell/PHB_sleep.js
+++ b/macro-item/spell/PHB_sleep.js
@@ -1,0 +1,70 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	// based on @ccjmk and @crymic macro for sleep. Gets targets and ignores those who are immune to sleep.
+	// uses convinient effects
+	// Midi-qol "On Use"
+
+	async function wait (ms) {
+		return new Promise((resolve) => {
+			setTimeout(resolve, ms);
+		});
+	}
+
+	const sleepHp = await args[0].damageTotal;
+	const condition = "Unconscious";
+	console.log(`Sleep Spell => Available HP Pool [${sleepHp}] points`);
+	const targets = await args[0].targets
+		.filter((i) => i.actor.system.attributes.hp.value !== 0 && !i.actor.effects.find((x) => (x.name ?? x.label) === condition))
+		.sort((a, b) => (canvas.tokens.get(a.id).actor.system.attributes.hp.value < canvas.tokens.get(b.id).actor.system.attributes.hp.value ? -1 : 1));
+	let remainingSleepHp = sleepHp;
+	let sleepTarget = [];
+
+	for (let target of targets) {
+		const findTarget = await canvas.tokens.get(target.id);
+		const immuneType = findTarget.actor.type === "character"
+			? ["undead", "construct"].some((race) => (findTarget.actor.system.details.race || "").toLowerCase().includes(race))
+			: ["undead", "construct"].some((value) => (findTarget.actor.system.details.type.value || "").toLowerCase().includes(value));
+		const immuneCI = findTarget.actor.system.traits.ci.custom.includes("Sleep");
+		const sleeping = findTarget.actor.effects.find((i) => (i.name ?? i.label) === condition);
+		const targetHpValue = findTarget.actor.system.attributes.hp.value;
+		const targetImg = target?.texture?.src;
+		if ((immuneType) || (immuneCI) || (sleeping)) {
+			console.log(`Sleep Results => Target: ${findTarget.name} | HP: ${targetHpValue} | Status: Resists`);
+			sleepTarget.push(`<div class="midi-qol-flex-container"><div>Resists</div><div class="midi-qol-target-npc midi-qol-target-name" id="${findTarget.id}"> ${findTarget.name}</div><div><img src="${targetImg}" width="30" height="30" style="border:0px"></div></div>`);
+		} else if (remainingSleepHp >= targetHpValue) {
+			remainingSleepHp -= targetHpValue;
+			console.log(`Sleep Results => Target: ${findTarget.name} |	HP: ${targetHpValue} | HP Pool: ${remainingSleepHp} | Status: Slept`);
+			sleepTarget.push(`<div class="midi-qol-flex-container"><div>Slept</div><div class="midi-qol-target-npc midi-qol-target-name" id="${findTarget.id}"> ${findTarget.name}</div><div><img src="${targetImg}" width="30" height="30" style="border:0px"></div></div>`);
+			const gameRound = game.combat ? game.combat.round : 0;
+			const effectData = {
+				label: "Sleep Spell",
+				name: "Sleep Spell",
+				icon: "icons/svg/sleep.svg",
+				origin: args[0].uuid,
+				disabled: false,
+				duration: {rounds: 10, seconds: 60, startRound: gameRound, startTime: game.time.worldTime},
+				flags: {dae: {specialDuration: ["isDamaged"]}},
+				changes: [
+					// { key: "macro.CE", mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM, value: "Prone", priority: 20 },
+					{key: "macro.CE", mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM, value: "Unconscious", priority: 20},
+				],
+			};
+
+			await MidiQOL.socket().executeAsGM("createEffects", {actorUuid: findTarget.actor.uuid, effects: [effectData]});
+		} else {
+			console.log(`Sleep Results => Target: ${target.name} | HP: ${targetHpValue} | HP Pool: ${remainingSleepHp - targetHpValue} | Status: Missed`);
+			sleepTarget.push(`<div class="midi-qol-flex-container"><div>misses</div><div class="midi-qol-target-npc midi-qol-target-name" id="${findTarget.id}"> ${findTarget.name}</div><div><img src="${targetImg}" width="30" height="30" style="border:0px"></div></div>`);
+		}
+	}
+	await wait(500);
+	const sleptResults = `<div><div class="midi-qol-nobox">${sleepTarget.join("")}</div></div>`;
+	const chatMessage = game.messages.get(args[0].itemCardId);
+	let content = duplicate(chatMessage.content);
+	const searchString = /<div class="midi-qol-hits-display">[\s\S]*<div class="end-midi-qol-hits-display">/g;
+	const replaceString = `<div class="midi-qol-hits-display"><div class="end-midi-qol-hits-display">${sleptResults}`;
+	content = await content.replace(searchString, replaceString);
+	await chatMessage.update({content: content});
+}

--- a/macro-item/spell/PHB_spike-growth.js
+++ b/macro-item/spell/PHB_spike-growth.js
@@ -1,0 +1,118 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	// FIXME(Future) seems broken in a non-obvious way
+	if (game) return;
+
+	if (!game.modules.get("ActiveAuras")?.active) {
+		ui.notifications.error("ActiveAuras is not enabled");
+		return;
+	}
+
+	if (!game.combat) {
+		ui.notifications.error("No combat, not applying effect");
+		return;
+	}
+
+	const lastArg = args[args.length - 1];
+	console.warn("macro caled", {
+		args,
+		isOnUse: args[0].tag === "OnUse" && args[0].macroPass === "preActiveEffects",
+		lastArgs: lastArg.tag === "OnUse" && lastArg.macroPass === "preActiveEffects",
+		lastArg,
+	});
+
+	if (args[0].tag === "OnUse" && args[0].macroPass === "preActiveEffects") {
+		return game.modules.get("ActiveAuras").api.AAHelpers.applyTemplate(args);
+	}
+
+	async function applySpikeGrowthDamage () {
+		const item = await fromUuid(lastArg.efData.origin);
+		const target = canvas.tokens.get(lastArg.tokenId);
+
+		const caster = item.parent;
+		const casterToken = canvas.tokens.placeables.find((t) => t.actor?.uuid === caster.uuid);
+		const damageRoll = await new CONFIG.Dice.DamageRoll(`2d4[piercing]`).evaluate({async: true});
+		if (game.dice3d) game.dice3d.showForRoll(damageRoll);
+		const workflowItemData = duplicate(item);
+		workflowItemData.system.components.concentration = false;
+		workflowItemData.system.duration = {value: null, units: "inst"};
+		workflowItemData.system.target = {value: null, width: null, units: "", type: "creature"};
+
+		setProperty(workflowItemData, "flags.itemacro", {});
+		setProperty(workflowItemData, "flags.midi-qol", {});
+		setProperty(workflowItemData, "flags.dae", {});
+		setProperty(workflowItemData, "effects", []);
+		delete workflowItemData._id;
+		workflowItemData.name = `${workflowItemData.name}: Movement Damage`;
+
+		await new MidiQOL.DamageOnlyWorkflow(
+			caster,
+			casterToken,
+			damageRoll.total,
+			"piercing",
+			[target],
+			damageRoll,
+			{
+				flavor: `(${CONFIG.DND5E.damageTypes["piercing"]})`,
+				itemCardId: "new",
+				itemData: workflowItemData,
+				isCritical: false,
+			},
+		);
+	}
+
+	function getDamageTestString (token, flags) {
+		console.warn("getDamageTestString", token);
+		return `${flags.origin}-${flags.round}-${flags.turn}-${flags.randomId}-${token.x}-${token.y}-${token.document?.elevation ?? token.elevation}`;
+	}
+
+	if (args[0] === "on") {
+		const safeName = (lastArg.efData.name ?? lastArg.efData.label).replace(/\s|'|\.|’/g, "_");
+		const item = await fromUuid(lastArg.efData.origin);
+		const targetItemTracker = DAE.getFlag(item.parent, `${safeName}ItemTracker`);
+		console.warn("token tracker on", targetItemTracker);
+		const originalTarget = targetItemTracker.targetUuids.includes(lastArg.tokenUuid);
+		const target = canvas.tokens.get(lastArg.tokenId);
+		const targetTokenTrackerFlag = DAE.getFlag(target, `${safeName}Tracker`);
+		const targetedThisCombat = targetTokenTrackerFlag && targetItemTracker.randomId === targetTokenTrackerFlag.randomId;
+		const targetTokenTracker = targetedThisCombat
+			? targetTokenTrackerFlag
+			: {
+				origin: lastArg.efData.origin,
+				randomId: targetItemTracker.randomId,
+				round: game.combat.round,
+				turn: game.combat.turn,
+				firstRound: true,
+			};
+
+		const testString = getDamageTestString(target, targetTokenTracker);
+		const existingTestString = hasProperty(targetTokenTracker, "testString");
+		const castTurn = targetItemTracker.startRound === game.combat.round && targetItemTracker.startTurn === game.combat.turn;
+
+		if (castTurn && originalTarget && targetTokenTracker.firstRound) {
+			console.debug(`Token ${target.name} is part of the original target for ${item.name}`);
+			targetTokenTracker.firstRound = false;
+		} else if (!existingTestString || (existingTestString && targetTokenTracker.testString !== testString)) {
+			await applySpikeGrowthDamage();
+		}
+
+		targetTokenTracker["testString"] = testString;
+		await DAE.setFlag(target, `${safeName}Tracker`, targetTokenTracker);
+		console.warn("taget", target);
+	}
+
+	if (args[0] === "off") {
+		const safeName = (lastArg.efData.name ?? lastArg.efData.label).replace(/\s|'|\.|’/g, "_");
+		const target = canvas.tokens.get(lastArg.tokenId);
+		const targetTrackerFlag = DAE.getFlag(target, `${safeName}Tracker`);
+
+		const token = await fromUuid(lastArg.tokenUuid);
+		targetTrackerFlag["testString"] = getDamageTestString(token, targetTrackerFlag);
+
+		await DAE.setFlag(token, `${safeName}Tracker`, targetTrackerFlag);
+		await game.modules.get("ActiveAuras").api.ActiveAuras.MainAura(token, "movement update", token.parent.id);
+	}
+}

--- a/macro-item/spell/PHB_spirit-guardians.js
+++ b/macro-item/spell/PHB_spirit-guardians.js
@@ -1,0 +1,47 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	const lastArg = args[args.length - 1];
+
+	// Check when applying the effect - if the token is not the caster and it IS the tokens turn they take damage
+	if (args[0] === "on" && args[1] !== lastArg.tokenId && lastArg.tokenId === game.combat?.current.tokenId) {
+		const sourceItem = await fromUuid(lastArg.origin);
+		const tokenOrActor = await fromUuid(lastArg.actorUuid);
+		const theActor = tokenOrActor.actor ? tokenOrActor.actor : tokenOrActor;
+		const DAEItem = lastArg.efData.flags.dae.itemData;
+		const damageType = getProperty(DAEItem, "flags.ddbimporter.damageType") || "radiant";
+
+		const itemData = mergeObject(
+			duplicate(sourceItem.data),
+			{
+				type: "weapon",
+				effects: [],
+				flags: {
+					"midi-qol": {
+						noProvokeReaction: true, // no reactions triggered
+						onUseMacroName: null, //
+					},
+				},
+				data: {
+					equipped: true,
+					actionType: "save",
+					save: {dc: Number.parseInt(args[3]), ability: "wis", scaling: "flat"},
+					damage: {parts: [[`${args[2]}d8`, damageType]]},
+					"target.type": "self",
+					components: {concentration: false, material: false, ritual: false, somatic: false, value: "", vocal: false},
+					duration: {units: "inst", value: undefined},
+					weaponType: "improv",
+				},
+			},
+			{overwrite: true, inlace: true, insertKeys: true, insertValues: true},
+		);
+		itemData.system.target.type = "self";
+		setProperty(itemData.flags, "autoanimations.killAnim", true);
+		// eslint-disable-next-line new-cap
+		const item = new CONFIG.Item.documentClass(itemData, {parent: theActor});
+		const options = {showFullCard: false, createWorkflow: true, versatile: false, configureDialog: false};
+		await MidiQOL.completeItemUse(item, {}, options);
+	}
+}

--- a/macro-item/spell/PHB_thunderous-smite.js
+++ b/macro-item/spell/PHB_thunderous-smite.js
@@ -1,0 +1,57 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	if (args[0].tag === "OnUse" && ["preTargeting"].includes(args[0].macroPass)) {
+		args[0].workflow.item.system["target"]["type"] = "self";
+		return;
+	}
+
+	try {
+		if (!["mwak"].includes(args[0].item.system.actionType)) return {};
+		if (args[0].hitTargetUuids.length === 0) return {}; // did not hit anyone
+		for (let tokenUuid of args[0].hitTargetUuids) {
+			const target = await fromUuid(tokenUuid);
+			const targetActor = target.actor;
+			if (!targetActor) continue;
+			const spellDC = actor.flags["midi-qol"].thunderousSmite.dc;
+			ChatMessage.create({content: `${targetActor.name} needs to make a ${CONFIG.DND5E.abilities["str"].label} DC${spellDC} vs Thunderous Smite Stagger.`});
+
+			const saveRollData = {
+				request: "save",
+				targetUuid: target.actor.uuid,
+				ability: "str",
+				options: {
+					chatMessage: true,
+					flavor: `${CONFIG.DND5E.abilities["str"]} DC${spellDC} vs Thunderous Smite Stagger`,
+				},
+			};
+
+			// const saveRoll = await targetActor.rollAbilitySave("str", { flavor });
+			const saveRoll = await MidiQOL.socket().executeAsGM("rollAbility", saveRollData);
+
+			if (saveRoll.total < spellDC) {
+				game.dfreds.effectInterface.addEffect({effectName: "Prone", uuid: tokenUuid});
+				ChatMessage.create({content: `${targetActor.name} has failed the save and is pushed back 10ft and knocked prone.`});
+			}
+		}
+		Hooks.once("midi-qol.RollComplete", (workflow) => {
+			console.log("Deleting concentration");
+			const effect = MidiQOL.getConcentrationEffect(actor);
+			if (effect) effect.delete();
+			return true;
+		});
+		const workflow = args[0].workflow;
+		const rollOptions = {
+			critical: workflow.isCritical,
+			criticalMultiplier: workflow.damageRoll?.options?.criticalMultiplier,
+			powerfulCritical: workflow.damageRoll?.options?.powerfulCritical,
+			multiplyNumeric: workflow.damageRoll?.options?.multiplyNumeric,
+		};
+		const damageFormula = new CONFIG.Dice.DamageRoll(`2d6[thunder]`, {}, rollOptions);
+		return {damageRoll: damageFormula.formula, flavor: "Thunderous Smite"};
+	} catch (err) {
+		console.error(`${args[0].itemData.name} - Thunderous Smite`, err);
+	}
+}

--- a/macro-item/spell/PHB_witch-bolt.js
+++ b/macro-item/spell/PHB_witch-bolt.js
@@ -1,0 +1,110 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	async function sustainedDamage ({options, damageType, damageDice, sourceItem, caster}) {
+		const damageRoll = await new CONFIG.Dice.DamageRoll(`${damageDice}[${damageType}]`).evaluate({async: true});
+		if (game.dice3d) game.dice3d.showForRoll(damageRoll, game.users.get(options.userId));
+
+		// console.warn({ options, damageType, damageDice, sourceItem, caster });
+		const targets = await Promise.all(options.targets.map(async (uuid) => {
+			const tok = await fromUuid(uuid);
+			return tok.object;
+		}));
+		const casterToken = await fromUuid(options.sourceUuid);
+		const itemData = sourceItem.toObject();
+		setProperty(itemData, "system.components.concentration", false);
+		itemData.effects = [];
+		delete itemData._id;
+
+		const workflow = await new MidiQOL.DamageOnlyWorkflow(
+			caster,
+			casterToken,
+			damageRoll.total,
+			damageType,
+			targets,
+			damageRoll,
+			{
+				flavor: `(${CONFIG.DND5E.damageTypes[damageType]})`,
+				itemCardId: "new",
+				itemData,
+				isCritical: false,
+			},
+		);
+	}
+
+	async function cancel (caster) {
+		const concentration = caster.effects.find((i) => i.name ?? i.label === "Concentrating");
+		if (concentration) {
+			await MidiQOL.socket().executeAsGM("removeEffects", {actorUuid: caster.uuid, effects: [concentration.id]});
+		}
+		await DAE.unsetFlag(caster, "witchBoltSpell");
+	}
+
+	const lastArg = args[args.length - 1];
+	const damageDice = "1d12";
+	const damageType = "lightning";
+
+	if (args[0].macroPass === "postActiveEffects") {
+		if (args[0].hitTargetUuids.length === 0) return {}; // did not hit anyone
+
+		const effectData = [{
+			label: "WitchBolt (Concentration)",
+			name: "WitchBolt (Concentration)",
+			icon: args[0].item.img,
+			duration: {rounds: 10, startTime: game.time.worldTime},
+			origin: args[0].item.uuid,
+			changes: [{
+				key: "macro.itemMacro.local",
+				value: "",
+				mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+				priority: 20,
+			}],
+			disabled: false,
+			"flags.dae.macroRepeat": "startEveryTurn",
+		}];
+
+		const options = {
+			targets: args[0].hitTargetUuids,
+			sourceUuid: args[0].tokenUuid,
+			distance: args[0].item.system.range.value,
+			userId: game.userId,
+		};
+
+		DAE.setFlag(args[0].actor, "witchBoltSpell", options);
+		await args[0].actor.createEmbeddedDocuments("ActiveEffect", effectData);
+	} else if (args[0] === "off") {
+		const sourceItem = await fromUuid(lastArg.origin);
+		const caster = sourceItem.parent;
+		DAE.unsetFlag(caster, "witchBoltSpell");
+	} else if (args[0] === "each") {
+		const sourceItem = await fromUuid(lastArg.origin);
+		const caster = sourceItem.parent;
+		const options = DAE.getFlag(caster, "witchBoltSpell");
+		const isInRange = await game.modules.get("plutonium-addon-automation")?.api.DdbImporter.effects.checkTargetInRange(options);
+		if (isInRange) {
+			const userIds = Object.entries(caster.ownership).filter((k) => k[1] === CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER).map((k) => k[0]);
+			const mes = await ChatMessage.create({
+				content: `<p>${caster.name} may use their action to sustain Witch Bolt.</p><br>`,
+				type: CONST.CHAT_MESSAGE_TYPES.OTHER,
+				speaker: caster.uuid,
+				whisper: game.users.filter((u) => userIds.includes(u.id) || u.isGM),
+			});
+			new Dialog({
+				title: sourceItem.name,
+				content: "<p>Use action to sustain Witch Bolt?</p>",
+				buttons: {
+					continue: {
+						label: "Yes, damage!",
+						callback: () => sustainedDamage({options, damageType, damageDice, sourceItem, caster}),
+					},
+					end: {
+						label: "No, end concentration",
+						callback: () => cancel(caster),
+					},
+				},
+			}).render(true);
+		}
+	}
+}

--- a/macro-item/spell/TCE_booming-blade.js
+++ b/macro-item/spell/TCE_booming-blade.js
@@ -1,0 +1,125 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	const lastArg = args[args.length - 1];
+
+	// macro vars
+	const sequencerFile = "jb2a.static_electricity.01.blue";
+	const sequencerScale = 1.5;
+	const damageType = "thunder";
+
+	// sequencer caller for effects on target
+	function sequencerEffect (target, file, scale) {
+		if (game.modules.get("sequencer")?.active && hasProperty(Sequencer.Database.entries, "jb2a")) {
+			new Sequence().effect().file(file).atLocation(target).scaleToObject(scale).play();
+		}
+	}
+
+	function weaponAttack (caster, sourceItemData, origin, target) {
+		const chosenWeapon = DAE.getFlag(caster, "boomingBladeChoice");
+		const filteredWeapons = caster.items.filter((i) => i.type === "weapon" && i.system.equipped);
+		const weaponContent = filteredWeapons
+			.map((w) => {
+				const selected = chosenWeapon && chosenWeapon === w.id ? " selected" : "";
+				return `<option value="${w.id}"${selected}>${w.name}</option>`;
+			})
+			.join("");
+
+		const content = `
+	<div class="form-group">
+	 <label>Weapons : </label>
+	 <select name="weapons"}>
+	 ${weaponContent}
+	 </select>
+	</div>
+	`;
+		new Dialog({
+			title: "Booming Blade: Choose a weapon to attack with",
+			content,
+			buttons: {
+				Ok: {
+					label: "Ok",
+					callback: async (html) => {
+						const characterLevel = caster.type === "character" ? caster.system.details.level : caster.system.details.cr;
+						const cantripDice = 1 + Math.floor((characterLevel + 1) / 6);
+						const itemId = html.find("[name=weapons]")[0].value;
+						const weaponItem = caster.getEmbeddedDocument("Item", itemId);
+						DAE.setFlag(caster, "boomingBladeChoice", itemId);
+						const weaponCopy = duplicate(weaponItem);
+						delete weaponCopy._id;
+						if (cantripDice > 0) {
+							weaponCopy.system.damage.parts[0][0] += ` + ${cantripDice - 1}d8[${damageType}]`;
+						}
+						weaponCopy.name = `${weaponItem.name} [Booming Blade]`;
+						weaponCopy.effects.push({
+							changes: [{key: "macro.itemMacro", mode: 0, value: "", priority: "20"}],
+							disabled: false,
+							duration: {rounds: 1},
+							icon: sourceItemData.img,
+							label: sourceItemData.name,
+							origin,
+							transfer: false,
+							flags: {targetUuid: target.uuid, casterUuid: caster.uuid, origin, cantripDice, damageType, dae: {specialDuration: ["turnStartSource", "isMoved"], transfer: false}},
+						});
+						setProperty(weaponCopy, "flags.itemacro", duplicate(sourceItemData.flags.itemacro));
+						setProperty(weaponCopy, "flags.midi-qol.effectActivation", false);
+						// eslint-disable-next-line new-cap
+						const attackItem = new CONFIG.Item.documentClass(weaponCopy, {parent: caster});
+						attackItem.prepareData();
+						attackItem.prepareFinalAttributes();
+						console.warn(attackItem);
+						const options = {showFullCard: false, createWorkflow: true, configureDialog: true};
+						await MidiQOL.completeItemUse(attackItem, {}, options);
+					},
+				},
+				Cancel: {
+					label: "Cancel",
+				},
+			},
+		}).render(true);
+	}
+
+	if (args[0].tag === "OnUse") {
+		if (lastArg.targets.length > 0) {
+			const casterData = await fromUuid(lastArg.actorUuid);
+			const caster = casterData.actor ? casterData.actor : casterData;
+			weaponAttack(caster, lastArg.itemData, lastArg.uuid, lastArg.targets[0]);
+		} else {
+			ui.notifications.error("Booming Blade: No target selected: please select a target and try again.");
+		}
+	} else if (args[0] === "on") {
+		const targetToken = canvas.tokens.get(lastArg.tokenId);
+		sequencerEffect(targetToken, sequencerFile, sequencerScale);
+	} else if (args[0] === "off") {
+		// uses midis move flag to determine if to apply extra damage
+		if (lastArg["expiry-reason"] === "midi-qol:isMoved" || lastArg["expiry-reaason"] === "midi-qol:isMoved") {
+			const targetToken = await fromUuid(lastArg.tokenUuid);
+			const sourceItem = await fromUuid(lastArg.efData.flags.origin);
+			const caster = sourceItem.parent;
+			const casterToken = canvas.tokens.placeables.find((t) => t.actor?.uuid === caster.uuid);
+			const damageRoll = await new CONFIG.Dice.DamageRoll(`${lastArg.efData.flags.cantripDice}d8[${damageType}]`).evaluate({async: true});
+			if (game.dice3d) game.dice3d.showForRoll(damageRoll);
+			const workflowItemData = duplicate(sourceItem.data);
+			workflowItemData.system.target = {value: 1, units: "", type: "creature"};
+			workflowItemData.name = "Booming Blade: Movement Damage";
+
+			await new MidiQOL.DamageOnlyWorkflow(
+				caster,
+				casterToken,
+				damageRoll.total,
+				damageType,
+				[targetToken.object], // bug in midi/levels auto cover can't cope with token
+				damageRoll,
+				{
+					flavor: `(${CONFIG.DND5E.damageTypes[damageType]})`,
+					itemCardId: "new",
+					itemData: workflowItemData,
+					isCritical: false,
+				},
+			);
+			sequencerEffect(targetToken, sequencerFile, sequencerScale);
+		}
+	}
+}

--- a/macro-item/spell/TCE_green-flame-blade.js
+++ b/macro-item/spell/TCE_green-flame-blade.js
@@ -1,0 +1,246 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	const lastArg = args[args.length - 1];
+
+	// macro vars
+	const damageType = "fire";
+	const freeSequence = "jb2a.particles.outward.greenyellow.01.05";
+	const patreonPrimary = "jb2a.dagger.melee.fire.green";
+	const patreonSecondary = "jb2a.chain_lightning.secondary.green";
+
+	const baseAutoAnimation = {
+		label: "WEAPON NAME",
+		macro: {
+			enable: false,
+		},
+		meleeSwitch: {
+			sound: {
+				enable: false,
+			},
+			options: {
+				detect: "automatic",
+				range: 2,
+				returning: false,
+				switchType: "on",
+			},
+		},
+		menu: "melee",
+		primary: {
+			video: {
+				dbSection: "melee",
+				menuType: "weapon",
+				animation: "shortsword",
+				variant: "01",
+				color: "white",
+				enableCustom: false,
+				customPath: "",
+			},
+			sound: {
+				enable: false,
+			},
+			options: {
+				contrast: 0,
+				delay: 0,
+				elevation: 1000,
+				isWait: false,
+				opacity: 1,
+				playbackRate: 1,
+				repeat: 1,
+				repeatDelay: 250,
+				saturate: 0,
+				size: 1,
+				tint: true,
+				tintColor: "#09ce68",
+				zIndex: 1,
+			},
+		},
+		secondary: {
+			enable: false,
+		},
+		source: {
+			enable: false,
+		},
+		target: {
+			enable: false,
+		},
+		isEnabled: true,
+		isCustomized: true,
+		fromAmmo: false,
+		version: 5,
+	};
+
+	// sequencer caller for effects on target
+	function sequencerEffect (target, origin = null) {
+		if (game.modules.get("sequencer")?.active) {
+			const secondary = Sequencer.Database.entryExists(patreonSecondary);
+			if (secondary) {
+				new Sequence()
+					.effect()
+					.atLocation(origin)
+					.stretchTo(target)
+					.file(patreonSecondary)
+					.repeats(1, 200, 300)
+					.randomizeMirrorY()
+					.play();
+			} else {
+				const attackAnimation = Sequencer.Database.entryExists(patreonPrimary)
+					? patreonPrimary
+					: Sequencer.Database.entryExists(freeSequence)
+						? freeSequence
+						: undefined;
+				if (attackAnimation) {
+					new Sequence()
+						.effect()
+						.file(attackAnimation)
+						.atLocation(target)
+						.play();
+				}
+			}
+		}
+	}
+
+	async function attackNearby (originToken, ignoreIds) {
+		const potentialTargets = await MidiQOL.findNearby(null, originToken, 5).filter((tok) => !ignoreIds.includes(tok.actor?.id));
+		if (potentialTargets.length === 0) return;
+		const sourceItem = await fromUuid(lastArg.efData.flags.origin);
+		const caster = sourceItem.parent;
+		const casterToken = canvas.tokens.placeables.find((t) => t.actor?.uuid === caster.uuid);
+		const targetContent = potentialTargets.map((t) => `<option value="${t.id}">${t.name}</option>`).join("");
+		const content = `<div class="form-group"><label>Targets : </label><select name="secondaryTargetId"}>${targetContent}</select></div>`;
+
+		new Dialog({
+			title: "Green Flame Blade: Choose a secondary target to attack",
+			content,
+			buttons: {
+				Choose: {
+					label: "Choose",
+					callback: async (html) => {
+						const selectedId = html.find("[name=secondaryTargetId]")[0].value;
+						const targetToken = canvas.tokens.get(selectedId);
+						const sourceItem = await fromUuid(lastArg.efData.flags.origin);
+						const mod = caster.system.abilities[sourceItem.abilityMod].mod;
+						const damageRoll = await new CONFIG.Dice.DamageRoll(`${lastArg.efData.flags.cantripDice - 1}d8[${damageType}] + ${mod}`).evaluate({async: true});
+						if (game.dice3d) game.dice3d.showForRoll(damageRoll);
+						const workflowItemData = duplicate(sourceItem);
+						workflowItemData.effects = [];
+						setProperty(workflowItemData, "flags.midi-qol", {});
+						workflowItemData.system.target = {value: 1, units: "", type: "creature"};
+						workflowItemData.system.range = {value: 5, long: null, units: "ft"};
+						delete workflowItemData._id;
+						workflowItemData.name = "Green Flame Blade: Secondary Damage";
+
+						await new MidiQOL.DamageOnlyWorkflow(
+							caster,
+							casterToken,
+							damageRoll.total,
+							damageType,
+							[targetToken],
+							damageRoll,
+							{
+								flavor: `(${CONFIG.DND5E.damageTypes[damageType]})`,
+								itemCardId: "new",
+								itemData: workflowItemData,
+								isCritical: false,
+							},
+						);
+						sequencerEffect(targetToken, originToken);
+					},
+				},
+				Cancel: {
+					label: "Cancel",
+				},
+			},
+		}).render(true);
+	}
+
+	function weaponAttack (caster, sourceItemData, origin, target) {
+		const chosenWeapon = DAE.getFlag(caster, "greenFlameBladeChoice");
+		const filteredWeapons = caster.items.filter((i) =>
+			i.type === "weapon" && i.system.equipped
+			&& i.system.activation.type === "action" && i.system.actionType === "mwak",
+		);
+		const weaponContent = filteredWeapons
+			.map((w) => {
+				const selected = chosenWeapon && chosenWeapon === w.id ? " selected" : "";
+				return `<option value="${w.id}"${selected}>${w.name}</option>`;
+			})
+			.join("");
+
+		const content = `<div class="form-group"><label>Weapons : </label><select name="weapons"}>${weaponContent}</select></div>`;
+		new Dialog({
+			title: "Green Flame Blade: Choose a weapon to attack with",
+			content,
+			buttons: {
+				Ok: {
+					label: "Ok",
+					callback: async (html) => {
+						const characterLevel = caster.type === "character" ? caster.system.details.level : caster.system.details.cr;
+						const cantripDice = 1 + Math.floor((characterLevel + 1) / 6);
+						const itemId = html.find("[name=weapons]")[0].value;
+						const weaponItem = caster.getEmbeddedDocument("Item", itemId);
+						DAE.setFlag(caster, "greenFlameBladeChoice", itemId);
+						const weaponCopy = duplicate(weaponItem);
+						delete weaponCopy._id;
+						if (cantripDice > 0) {
+							weaponCopy.system.damage.parts[0][0] += ` + ${cantripDice - 1}d8[${damageType}]`;
+						}
+						weaponCopy.name = `${weaponItem.name} [Green Flame Blade]`;
+						weaponCopy.effects.push({
+							changes: [{key: "macro.itemMacro", mode: 0, value: "", priority: "20"}],
+							disabled: false,
+							// duration: { turns: 0 },
+							duration: {turns: 1},
+							icon: sourceItemData.img,
+							label: sourceItemData.name,
+							name: sourceItemData.name,
+							origin,
+							transfer: false,
+							flags: {targetUuid: target.uuid, casterId: caster.id, origin, cantripDice, damageType, dae: {specialDuration: ["1Action", "1Attack", "turnStartSource"], transfer: false}},
+						});
+						setProperty(weaponCopy, "flags.itemacro", duplicate(sourceItemData.flags.itemacro));
+						setProperty(weaponCopy, "flags.midi-qol.effectActivation", false);
+						if (game.modules.get("sequencer")?.active && Sequencer.Database.entryExists(patreonPrimary)) {
+							const autoAnimationsAdjustments = duplicate(baseAutoAnimation);
+							autoAnimationsAdjustments.primary.video.animation = weaponCopy.system.baseItem ? weaponCopy.system.baseItem : "shortsword";
+							const autoanimations = hasProperty(weaponCopy, "flags.autoanimations")
+								? mergeObject(getProperty(weaponCopy, "flags.autoanimations"), autoAnimationsAdjustments)
+								: autoAnimationsAdjustments;
+							setProperty(weaponCopy, "flags.autoanimations", autoanimations);
+						}
+						// eslint-disable-next-line new-cap
+						const attackItem = new CONFIG.Item.documentClass(weaponCopy, {parent: caster});
+						attackItem.prepareData();
+						attackItem.prepareFinalAttributes();
+						const options = {showFullCard: false, createWorkflow: true, configureDialog: true};
+						await MidiQOL.completeItemUse(attackItem, {}, options);
+					},
+				},
+				Cancel: {
+					label: "Cancel",
+				},
+			},
+		}).render(true);
+	}
+
+	if (args[0].tag === "OnUse") {
+		if (lastArg.targets.length > 0) {
+			// console.warn(lastArg);
+			const casterData = await fromUuid(lastArg.actorUuid);
+			const caster = casterData.actor ? casterData.actor : casterData;
+			// console.warn({
+			//	 caster, itemData: lastArg.itemData, uuid: lastArg.uuid, targets: lastArg.targets[0]
+			// })
+			weaponAttack(caster, lastArg.itemData, lastArg.uuid, lastArg.targets[0]);
+		} else {
+			ui.notifications.error("Green Flame Blade: No target selected: please select a target and try again.");
+		}
+	} else if (args[0] === "on") {
+		const targetToken = canvas.tokens.get(lastArg.tokenId);
+		const casterId = lastArg.efData.flags.casterId;
+		console.log(`Checking ${targetToken.name} for nearby tokens for Green-Flame Blade from ${casterId}`);
+		await attackNearby(targetToken, [casterId]);
+	}
+}

--- a/macro-item/spell/TCE_spirit-shroud.js
+++ b/macro-item/spell/TCE_spirit-shroud.js
@@ -1,0 +1,79 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	// an OnUse macro used with Midi provided by @kaelad
+
+	function addDamageType (damageType, caster) {
+		// find the active effect
+		const dice = Math.floor((args[0].spellLevel - 1) / 2);
+		DAE.setFlag(caster, "spiritShroud", {dice, type: damageType});
+	}
+
+	function selectDamage (caster) {
+		// ask for the damage type
+		new Dialog({
+			title: "Choose the damage type",
+			buttons: {
+				cold: {
+					icon: `<i class="fas fa-snowflake"></i>`,
+					label: "Cold",
+					callback: () => addDamageType("cold", caster),
+				},
+				necrotic: {
+					icon: `<i class="fas fa-skull-crossbones"></i>`,
+					label: "Necrotic",
+					callback: () => addDamageType("necrotic", caster),
+				},
+				radiant: {
+					icon: `<i class="fas fa-star-of-life"></i>`,
+					label: "Radiant",
+					callback: () => addDamageType("radiant", caster),
+				},
+			},
+		}).render(true);
+	}
+
+	// onUse macro
+	if (args[0].hitTargets.length === 0) return;
+
+	if (args[0].tag === "OnUse") {
+		const tokenOrActor = await fromUuid(args[0].actorUuid);
+		const caster = tokenOrActor.actor ? tokenOrActor.actor : tokenOrActor;
+
+		const effectData = {
+			changes: [
+				{
+					key: "flags.dnd5e.DamageBonusMacro",
+					mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+					value: `ItemMacro.${args[0].item.name}`,
+					priority: 20,
+				}, // macro to apply the damage
+			],
+			origin: args[0].itemUuid,
+			disabled: false,
+			duration: args[0].item.effects[0].duration,
+			icon: args[0].item.img,
+			label: args[0].item.name,
+			name: args[0].item.name,
+		};
+		effectData.duration.startTime = game.time.worldTime;
+		await caster.createEmbeddedDocuments("ActiveEffect", [effectData]);
+		selectDamage(caster);
+	} else if (args[0].tag === "DamageBonus") {
+		// only attacks
+		if (!["mwak", "rwak", "rsak", "msak"].includes(args[0].item.system.actionType)) return {};
+		const target = args[0].hitTargets[0];
+		// only on the marked target
+		if (!hasProperty(target.actor.data, "flags.midi-qol.spiritShroud")) return {};
+		const tokenOrActor = await fromUuid(args[0].actorUuid);
+		const caster = tokenOrActor.actor ? tokenOrActor.actor : tokenOrActor;
+		const data = DAE.getFlag(caster, "spiritShroud");
+		const damageType = args[0].item.system.damage.parts[0][1];
+		const diceNumber = data.dice;
+		const diceMult = args[0].isCritical ? 2 * diceNumber : diceNumber;
+		const damage = {damageRoll: `${diceMult}d8[${damageType}]`, flavor: "Spirit Shroud Damage"};
+		return damage;
+	}
+}

--- a/macro-item/spell/XGE_absorb-elements.js
+++ b/macro-item/spell/XGE_absorb-elements.js
@@ -1,0 +1,60 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	const itemName = args[0].itemData.name;
+	const targetActor = args[0].tokenUuid
+		? (await fromUuid(args[0].tokenUuid)).actor
+		: game.actors.get(args[0].actorId);
+
+	async function updateEffects (html) {
+		const element = html.find("#element").val();
+		const effect = targetActor.effects.find((i) => (i.name ?? i.label) === `${itemName} - Extra Damage`);
+		const changes = duplicate(effect.changes);
+		changes[0].value += `[${element}]`;
+		changes[1].value += `[${element}]`;
+		await effect.update({changes});
+		const resistanceEffect = targetActor.effects.find((i) => (i.name ?? i.label) === `${itemName} - Resistance`);
+		const resistanceChanges = duplicate(resistanceEffect.changes);
+		resistanceChanges[0].value = element;
+		await resistanceEffect.update({changes: resistanceChanges});
+	}
+
+	await new Promise(resolve => {
+		let isButtonClose = false;
+		new Dialog({
+			title: "Choose a damage type",
+			content: `
+			<form class="flexcol">
+			  <div class="form-group">
+				 <select id="element">
+					<option value="acid">Acid</option>
+					<option value="cold">Cold</option>
+					<option value="fire">Fire</option>
+					<option value="lightning">Lightning</option>
+					<option value="thunder">Thunder</option>
+				 </select>
+			  </div>
+			</form>`,
+			// select element type
+			buttons: {
+				yes: {
+					icon: "<i class=\"fas fa-bolt\"></i>",
+					label: "Select",
+					callback: async (html) => {
+						isButtonClose = true;
+						try {
+							await updateEffects(html);
+						} finally {
+							resolve();
+						}
+					},
+				},
+			},
+			close: () => {
+				if (!isButtonClose) resolve();
+			},
+		}).render(true);
+	});
+}

--- a/macro-item/spell/XGE_crown-of-stars.js
+++ b/macro-item/spell/XGE_crown-of-stars.js
@@ -1,0 +1,63 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	// DAE Item Macro, pass spell level
+
+	const lastArg = args[args.length - 1];
+	const tokenOrActor = await fromUuid(lastArg.actorUuid);
+	const target = tokenOrActor.actor ? tokenOrActor.actor : tokenOrActor;
+	const castItemName = "Summoned Crown of Stars";
+
+	/**
+	 * Create Crown of Stars item in inventory
+	 */
+	if (args[0] === "on") {
+		const castItem = target.items.find((i) => i.name === castItemName && i.type === "weapon");
+		if (!castItem) {
+			const DAEItem = lastArg.efData.flags.dae.itemData;
+			const stars = 7 + ((args[1] - 7) * 2);
+			const uuid = randomID();
+			const weaponData = {
+				_id: uuid,
+				name: castItemName,
+				type: "weapon",
+				system: {
+					quantity: 1,
+					activation: {type: "bonus", cost: 1, condition: ""},
+					target: {value: 1, type: "creature"},
+					range: {value: 120, long: null, units: "ft"},
+					uses: {value: stars, max: stars, per: "charges"},
+					ability: DAEItem.system.ability,
+					actionType: "rsak",
+					attackBonus: DAEItem.system.attackBonus,
+					chatFlavor: "",
+					critical: null,
+					damage: {parts: [["4d12", "radiant"]], versatile: ""},
+					weaponType: "simpleR",
+					proficient: true,
+					equipped: true,
+					description: DAEItem.system.description,
+					consume: {type: "charges", target: uuid, amount: 1},
+				},
+				flags: {CrownOfStars: target.id, ddbimporter: {ignoreItemUpdate: true}},
+				img: DAEItem.img,
+			};
+
+			await target.createEmbeddedDocuments("Item", [weaponData], {keepId: true});
+			ui.notifications.notify("Crown of Stars created in your inventory");
+		}
+	}
+
+	// NEEDED: reduce ATL effect to dim light when stars drop below 5
+
+	// Delete Crown of Stars
+	if (args[0] === "off") {
+		const blades = target.items.filter((i) => i.flags?.CrownOfStars === target.id);
+		if (blades.length > 0) {
+			await target.deleteEmbeddedDocuments("Item", blades.map((s) => s.id));
+			ui.notifications.notify("Crown of Stars removed from your inventory");
+		}
+	}
+}

--- a/macro-item/spell/XGE_ice-knife.js
+++ b/macro-item/spell/XGE_ice-knife.js
@@ -1,0 +1,57 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	// Midi-qol "on use"
+	const lastArg = args[args.length - 1];
+	const tokenOrActor = await fromUuid(lastArg.actorUuid);
+	const casterActor = tokenOrActor.actor ? tokenOrActor.actor : tokenOrActor;
+
+	if (lastArg.targets.length > 0) {
+		let areaSpellData = duplicate(lastArg.item);
+		const damageDice = 1 + lastArg.spellLevel;
+		delete (areaSpellData.effects);
+		delete (areaSpellData.id);
+		delete (areaSpellData.flags["midi-qol"].onUseMacroName);
+		delete (areaSpellData.flags["midi-qol"].onUseMacroParts);
+		delete (areaSpellData.flags.itemacro);
+		areaSpellData.name = "Ice Knife: Explosion";
+		areaSpellData.system.damage.parts = [[`${damageDice}d6[cold]`, "cold"]];
+		areaSpellData.system.actionType = "save";
+		areaSpellData.system.save.ability = "dex";
+		areaSpellData.system.scaling = {mode: "level", formula: "1d6"};
+		areaSpellData.system.preparation.mode = "atwill";
+		areaSpellData.system.target.value = 99;
+		// eslint-disable-next-line new-cap
+		const areaSpell = new CONFIG.Item.documentClass(areaSpellData, {parent: casterActor});
+		const target = canvas.tokens.get(lastArg.targets[0].id);
+		const aoeTargets = MidiQOL
+			.findNearby(null, target, 5, {includeIncapacitated: true})
+			.filter((possible) => {
+				const collisionRay = new Ray(target, possible);
+				const collision = canvas.walls.checkCollision(collisionRay, {mode: "any", type: "sight"});
+				if (collision) return false;
+				else return true;
+			})
+			.concat(target)
+			.map((t) => t.document.uuid);
+
+		const options = {
+			showFullCard: false,
+			createWorkflow: true,
+			targetUuids: aoeTargets,
+			configureDialog: false,
+			versatile: false,
+			consumeResource: false,
+			consumeSlot: false,
+			// workflowOptions: {
+			//   autoRollDamage: 'always'
+			// }
+		};
+
+		await MidiQOL.completeItemUse(areaSpell, {}, options);
+	} else {
+		ui.notifications.error("Ice Knife: No target selected: unable to automate burst effect.");
+	}
+}

--- a/macro-item/spell/XGE_storm-sphere.js
+++ b/macro-item/spell/XGE_storm-sphere.js
@@ -1,0 +1,62 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	const lastArg = args[args.length - 1];
+
+	const castItemName = "Storm Sphere Attack";
+	const tokenOrActor = await fromUuid(lastArg.actorUuid);
+	const targetActor = tokenOrActor.actor ? tokenOrActor.actor : tokenOrActor;
+	const castItem = targetActor.items.find((i) => i.name === castItemName && i.type === "spell");
+
+	if (args[0].tag === "OnUse") {
+		await game.modules.get("ActiveAuras").api.AAHelpers.applyTemplate(args);
+		// place templates
+		const spellLevel = lastArg.spellLevel;
+		const DAEItem = lastArg.itemData;
+
+		if (!castItem) {
+			const spell = {
+				name: castItemName,
+				type: "spell",
+				system: {
+					description: DAEItem.system.description,
+					activation: {type: "bonus"},
+					ability: DAEItem.system.ability,
+					attackBonus: DAEItem.system.attackBonus,
+					actionType: "rsak",
+					damage: {parts: [[`${spellLevel}d6[lightning]`, "lightning"]], versatile: ""},
+					level: 0,
+					school: DAEItem.system.school,
+					preparation: {mode: "prepared", prepared: false},
+					scaling: {mode: "none", formula: ""},
+				},
+				flags: {ddbimporter: {ignoreItemUpdate: true}},
+				img: DAEItem.img,
+				effects: [],
+			};
+			await targetActor.createEmbeddedDocuments("Item", [spell]);
+			ui.notifications.notify(`${castItemName} created in your spellbook`);
+			const effectData = [{
+				label: castItemName,
+				icon: DAEItem.img,
+				duration: {min: 10, startTime: game.time.worldTime},
+				origin: lastArg.sourceItemUuid,
+				changes: [{
+					key: "macro.itemMacro",
+					value: "",
+					mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+					priority: 20,
+				}],
+				disabled: false,
+			}];
+			await targetActor.createEmbeddedDocuments("ActiveEffect", effectData);
+		}
+	}
+
+	if (args[0] === "off") {
+		// Delete Storm Sphere Attack
+		if (castItem) targetActor.deleteEmbeddedDocuments("Item", [castItem.id]);
+	}
+}

--- a/macro-item/spell/XGE_zephyr-strike.js
+++ b/macro-item/spell/XGE_zephyr-strike.js
@@ -1,0 +1,32 @@
+/**
+ * Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+ * See: `../../license/ddb-importer.md`
+ */
+async function macro (args) {
+	const lastArg = args[args.length - 1];
+	const tokenOrActor = await fromUuid(lastArg.actorUuid);
+	const targetActor = tokenOrActor.actor ? tokenOrActor.actor : tokenOrActor;
+	const gameRound = game.combat ? game.combat.round : 0;
+
+	const effectData = {
+		label: "Zephyr Strike: Speed",
+		name: "Zephyr Strike: Speed",
+		icon: lastArg.itemData.img,
+		origin: lastArg.uuid,
+		disabled: false,
+		duration: {round: 1, startRound: gameRound, startTime: game.time.worldTime},
+		changes: [
+			{
+				key: "system.attributes.movement.all",
+				value: "+ 30",
+				mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+				priority: 20,
+			},
+		],
+		flags: {dae: {specialDuration: ["turnEndSource"]}},
+	};
+
+	ChatMessage.create({content: `${targetActor.name} gains 30ft of movement until the end of their turn`});
+
+	await MidiQOL.socket().executeAsGM("createEffects", {actorUuid: targetActor.uuid, effects: [effectData]});
+}

--- a/module/data/spell/__core.json
+++ b/module/data/spell/__core.json
@@ -1,6 +1,75 @@
 {
 	"spell": [
 		{
+			"name": "Absorb Elements",
+			"source": "XGE",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "system.bonuses.mwak.damage",
+							"value": "(@item.level)d6",
+							"mode": "CUSTOM",
+							"priority": 20
+						},
+						{
+							"key": "system.bonuses.msak.damage",
+							"value": "(@item.level)d6",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"rounds": 2,
+						"startTurn": 1
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"specialDuration": [
+								"DamageDealt"
+							]
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Absorb Elements - Extra Damage"
+				},
+				{
+					"changes": [
+						{
+							"key": "system.traits.dr.value",
+							"value": "fire",
+							"mode": "ADD",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"rounds": 2
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Absorb Elements - Resistance"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "XGE_absorb-elements.js"
+			}
+		},
+		{
 			"name": "Aid",
 			"source": "PHB",
 			"system": {
@@ -71,6 +140,47 @@
 			]
 		},
 		{
+			"name": "Armor of Agathys",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.dae.onUpdateTarget",
+							"mode": "CUSTOM",
+							"value": "Armor of Agathys,ItemMacro,system.attributes.hp.temp,@item.level",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"seconds": 3600
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"selfTarget": true,
+							"selfTargetAlways": true
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Armor of Agathys"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			},
+			"_merge": {
+				"system": true
+			},
+			"itemMacro": {
+				"file": "PHB_armor-of-agathys.js"
+			}
+		},
+		{
 			"name": "Arms of Hadar",
 			"source": "PHB",
 			"system": {
@@ -88,6 +198,61 @@
 					"convenientEffect": "Reaction"
 				}
 			]
+		},
+		{
+			"name": "Aura of Life",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "system.traits.dr.value",
+							"mode": "ADD",
+							"value": "necrotic",
+							"priority": "20"
+						},
+						{
+							"key": "macro.itemMacro",
+							"value": "@token",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"macroRepeat": "startEveryTurn"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						},
+						"ActiveAuras": {
+							"isAura": true,
+							"aura": "Allies",
+							"radius": 30,
+							"displayTemp": true
+						}
+					},
+					"name": "Aura of Life",
+					"requires": {
+						"ActiveAuras": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_aura-of-life.js"
+			},
+			"system": {
+				"target.type": "self",
+				"range.units": "self",
+				"actionType": "other",
+				"damage.parts": []
+			}
 		},
 		{
 			"name": "Aura of Purity",
@@ -203,6 +368,76 @@
 			]
 		},
 		{
+			"name": "Booming Blade",
+			"source": "TCE",
+			"_merge": {
+				"system": true
+			},
+			"system": {
+				"damage.parts": [],
+				"damage.versatile": "",
+				"actionType": "other"
+			},
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "TCE_booming-blade.js"
+			}
+		},
+		{
+			"name": "Branding Smite",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.dnd5e.DamageBonusMacro",
+							"value": "ItemMacro.Branding Smite",
+							"mode": "CUSTOM",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.brandingSmite.level",
+							"value": "@item.level",
+							"mode": "OVERRIDE",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"specialDuration": [
+								"1Hit:rwak",
+								"1Hit:mwak"
+							]
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Branding Smite"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_branding-smite.js"
+			},
+			"system": {
+				"target.type": "self",
+				"actionType": "other",
+				"damage.parts": []
+			}
+		},
+		{
 			"name": "Chill Touch",
 			"source": "PHB",
 			"system": {
@@ -250,6 +485,290 @@
 			]
 		},
 		{
+			"name": "Chromatic Orb",
+			"source": "PHB",
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postDamageRoll]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_chromatic-orb.js"
+			}
+		},
+		{
+			"name": "Cloudkill",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.OverTime",
+							"mode": "CUSTOM",
+							"value": "label=Cloudkill (Start of Turn),turn=start, saveAbility=con, killAnim=true, saveDC=@attributes.spelldc, saveDamage=halfdamage, rollType=save, saveMagic=true, damageBeforeSave=false, damageRoll=(@item.level)d8, damageType=poison",
+							"priority": "20"
+						},
+						{
+							"key": "macro.itemMacro",
+							"value": "@item.level",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"seconds": 600
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						},
+						"ActiveAuras": {
+							"isAura": true,
+							"aura": "All",
+							"radius": 20,
+							"save": "str",
+							"displayTemp": true
+						}
+					},
+					"name": "Cloudkill",
+					"requires": {
+						"ActiveAuras": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[preActiveEffects]ItemMacro",
+					"forceCEOff": true
+				},
+				"plutonium-addon-automation": {
+					"effect": {
+						"dice": "5d8[poison]",
+						"damageType": "poison",
+						"save": "",
+						"sequencerFile": "jb2a.fog_cloud.2.green"
+					}
+				}
+			},
+			"itemMacro": {
+				"file": "Generic_ddbi-aa-damage-on-entry.js"
+			},
+			"system": {
+				"damage.parts": [],
+				"actionType": "other"
+			}
+		},
+		{
+			"name": "Color Spray",
+			"source": "PHB",
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"effects": [],
+			"itemMacro": {
+				"file": "PHB_color-spray.js"
+			},
+			"system": {
+				"damage.parts": [
+					[
+						"6d10",
+						"midi-none"
+					]
+				]
+			}
+		},
+		{
+			"name": "Comprehend Languages",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "system.traits.languages.all",
+							"mode": "CUSTOM",
+							"value": "1",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Comprehend Languages"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			}
+		},
+		{
+			"name": "Create Bonfire",
+			"source": "XGE",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.OverTime",
+							"mode": "CUSTOM",
+							"value": "turn=end,label=Create Bonfire (End of Turn),damageRoll=(@cantripDice)d8,damageType=fire,saveRemove=false,saveDC=@attributes.spelldc,saveAbility=dex,saveDamage=nodamage,killAnim=true",
+							"priority": "20"
+						},
+						{
+							"key": "macro.itemMacro",
+							"value": "",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"seconds": 60,
+						"rounds": 10
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						},
+						"ActiveAuras": {
+							"isAura": true,
+							"aura": "All",
+							"save": "dex",
+							"displayTemp": true
+						}
+					},
+					"name": "Create Bonfire",
+					"requires": {
+						"ActiveAuras": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[preActiveEffects]ItemMacro",
+					"forceCEOff": true
+				},
+				"plutonium-addon-automation": {
+					"effect": {
+						"dice": "1d8[fire]",
+						"damageType": "fire",
+						"save": "",
+						"sequencerFile": "jb2a.flames.01.orange",
+						"sequencerScale": 2,
+						"isCantrip": true,
+						"saveOnEntry": true
+					}
+				}
+			},
+			"itemMacro": {
+				"file": "Generic_ddbi-aa-damage-on-entry.js"
+			},
+			"system": {
+				"save.ability": null
+			}
+		},
+		{
+			"name": "Crown of Madness",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "StatusEffect",
+							"mode": "CUSTOM",
+							"value": "Convenient Effect: Charmed",
+							"priority": 20
+						},
+						{
+							"key": "flags.midi-qol.OverTime",
+							"mode": "OVERRIDE",
+							"value": "label=Crown of Madness (End of Turn),turn=end,saveDC=@attributes.spelldc,saveAbility=wis,saveMagic=true,killAnim=true",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Crown of Madness"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			}
+		},
+		{
+			"name": "Crown of Stars",
+			"source": "XGE",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "ATL.light.dim",
+							"mode": "UPGRADE",
+							"value": "60",
+							"priority": 20
+						},
+						{
+							"key": "ATL.light.bright",
+							"mode": "UPGRADE",
+							"value": "30",
+							"priority": 20
+						},
+						{
+							"key": "macro.itemMacro",
+							"value": "@spellLevel",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"selfTarget": true,
+							"selfTargetAlways": true
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Crown of Stars"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "XGE_crown-of-stars.js"
+			},
+			"system": {
+				"actionType": "other",
+				"damage.parts": []
+			}
+		},
+		{
 			"name": "Darkvision",
 			"source": "PHB",
 			"effects": [
@@ -279,6 +798,84 @@
 			"source": "PHB",
 			"system": {
 				"damage.parts": []
+			}
+		},
+		{
+			"name": "Elemental Weapon",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "macro.itemMacro",
+							"value": "@item.level",
+							"mode": "CUSTOM",
+							"priority": 0
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Elemental Weapon"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_elemental-weapon.js"
+			},
+			"system": {
+				"scaling.mode": "none",
+				"scaling.formula": ""
+			}
+		},
+		{
+			"name": "Ensnaring Strike",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.onUseMacroName",
+							"value": "ItemMacro.Ensnaring Strike,postActiveEffects",
+							"mode": "CUSTOM",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"selfTarget": true,
+							"selfTargetAlways": true
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Ensnaring Strike"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[preTargeting]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_ensnaring-strike.js"
+			},
+			"system": {
+				"actionType": "other",
+				"damage.parts": [],
+				"save.ability": null
 			}
 		},
 		{
@@ -344,6 +941,120 @@
 			]
 		},
 		{
+			"name": "Green-Flame Blade",
+			"source": "TCE",
+			"_merge": {
+				"system": true
+			},
+			"system": {
+				"damage.parts": [],
+				"damage.versatile": "",
+				"actionType": "other"
+			},
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "TCE_green-flame-blade.js"
+			}
+		},
+		{
+			"name": "Guidance",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.optional.guidance.label",
+							"mode": "CUSTOM",
+							"value": "Guidance",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.optional.guidance.check.all",
+							"mode": "CUSTOM",
+							"value": "+ 1d4",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.optional.guidance.skill.all",
+							"mode": "CUSTOM",
+							"value": "+ 1d4",
+							"priority": "20"
+						},
+						{
+							"key": "system.attributes.init.bonus",
+							"mode": "CUSTOM",
+							"value": "+ 1d4",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"specialDuration": [
+								"isSkill",
+								"isCheck",
+								"isInitiative"
+							]
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Guidance"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			}
+		},
+		{
+			"name": "Hail of Thorns",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.onUseMacroName",
+							"value": "ItemMacro.Hail of Thorns,postActiveEffects",
+							"mode": "CUSTOM",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"selfTarget": true,
+							"selfTargetAlways": true
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Hail of Thorns"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_hail-of-thorns.js"
+			},
+			"system": {
+				"damage.parts": [],
+				"actionType": "other",
+				"save.ability": null
+			}
+		},
+		{
 			"name": "Haste",
 			"source": "PHB",
 			"effects": [
@@ -406,6 +1117,38 @@
 			]
 		},
 		{
+			"name": "Hex",
+			"source": "PHB",
+			"_merge": {
+				"system": true
+			},
+			"effects": [
+				{
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Marked"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_hex.js"
+			},
+			"system": {
+				"damage.parts": []
+			}
+		},
+		{
 			"name": "Hold Person",
 			"source": "PHB",
 			"effects": [
@@ -426,6 +1169,216 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Hunter's Mark",
+			"source": "PHB",
+			"_merge": {
+				"system": true
+			},
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.dae.onUpdateSource",
+							"mode": "CUSTOM",
+							"value": "Hunter's Mark",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"seconds": 3600
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Marked"
+				},
+				{
+					"changes": [
+						{
+							"key": "flags.dnd5e.DamageBonusMacro",
+							"value": "ItemMacro",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"transfer": true,
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Hunter's Mark"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_hunter's-mark.js"
+			},
+			"system": {
+				"damage.parts": []
+			}
+		},
+		{
+			"name": "Ice Knife",
+			"source": "XGE",
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "XGE_ice-knife.js"
+			},
+			"system": {
+				"target": {
+					"value": 1,
+					"type": "creature"
+				},
+				"damage.parts": [
+					[
+						"1d10",
+						"piercing"
+					]
+				],
+				"scaling.formula": ""
+			}
+		},
+		{
+			"name": "Incendiary Cloud",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.OverTime",
+							"mode": "CUSTOM",
+							"value": "label=Incendiary Cloud Turn End,turn=end, saveAbility=dex, saveDC=@attributes.spelldc, saveDamage=halfdamage, rollType=save, saveMagic=true, damageBeforeSave=false, damageRoll=(@item.level)d8, damageType=fire,killAnim=true",
+							"priority": "20"
+						},
+						{
+							"key": "macro.itemMacro",
+							"value": "@item.level",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"seconds": 60
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						},
+						"ActiveAuras": {
+							"isAura": true,
+							"aura": "All",
+							"radius": 20,
+							"save": "dex",
+							"displayTemp": true
+						}
+					},
+					"name": "Incendiary Cloud",
+					"requires": {
+						"ActiveAuras": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[preActiveEffects]ItemMacro",
+					"forceCEOff": true
+				},
+				"plutonium-addon-automation": {
+					"effect": {
+						"dice": "10d8[fire]",
+						"damageType": "fire",
+						"save": "",
+						"sequencerFile": "jb2a.fumes.fire.orange"
+					}
+				}
+			},
+			"itemMacro": {
+				"file": "Generic_ddbi-aa-damage-on-entry.js"
+			}
+		},
+		{
+			"name": "Insect Plague",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.OverTime",
+							"mode": "CUSTOM",
+							"value": "label=Insect Plague Turn End,turn=end, saveAbility=con, saveDC=@attributes.spelldc, saveDamage=halfdamage, rollType=save, saveMagic=true, damageBeforeSave=false, damageRoll=(@item.level)d10, damageType=piercing, killAnim=true",
+							"priority": "20"
+						},
+						{
+							"key": "macro.itemMacro",
+							"value": "@item.level",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"seconds": 600
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						},
+						"ActiveAuras": {
+							"isAura": true,
+							"aura": "All",
+							"radius": 20,
+							"save": "dex",
+							"displayTemp": true
+						}
+					},
+					"name": "Insect Plague",
+					"requires": {
+						"ActiveAuras": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[preActiveEffects]ItemMacro",
+					"forceCEOff": true
+				},
+				"plutonium-addon-automation": {
+					"effect": {
+						"dice": "4d10[piercing]",
+						"damageType": "piercing",
+						"save": "",
+						"sequencerFile": "jb2a.butterflies.many.orange"
+					}
+				}
+			},
+			"itemMacro": {
+				"file": "Generic_ddbi-aa-damage-on-entry.js"
+			}
 		},
 		{
 			"name": "Invisibility",
@@ -449,6 +1402,144 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "Light",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "ATL.light.dim",
+							"mode": "OVERRIDE",
+							"value": "40",
+							"priority": 20
+						},
+						{
+							"key": "ATL.light.bright",
+							"mode": "OVERRIDE",
+							"value": "20",
+							"priority": 20
+						},
+						{
+							"key": "ATL.light.color",
+							"mode": "OVERRIDE",
+							"value": "#ffffff",
+							"priority": 20
+						},
+						{
+							"key": "ATL.light.alpha",
+							"mode": "OVERRIDE",
+							"value": "0.25",
+							"priority": 20
+						},
+						{
+							"key": "ATL.light.animation",
+							"mode": "OVERRIDE",
+							"value": "{\"type\": \"pulse\", \"speed\": 3,\"intensity\": 1}",
+							"priority": 20
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Light"
+				}
+			],
+			"flags": {
+				"midiProperties": {
+					"autoFailFriendly": true
+				},
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			}
+		},
+		{
+			"name": "Melf's Acid Arrow",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.OverTime",
+							"mode": "CUSTOM",
+							"value": "label=Melf's Acid Arrow (End of Turn),turn=end,damageRoll=(@spellLevel)d4[acid],damageType=acid,killAnim=true",
+							"priority": "20"
+						}
+					],
+					"duration": {
+						"rounds": 1
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"specialDuration": [
+								"turnEnd"
+							]
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Melf's Acid Arrow"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			},
+			"system": {
+				"target.value": 1,
+				"target.units": null,
+				"target.type": "creature",
+				"damage.parts": [
+					[
+						"4d4",
+						"acid"
+					]
+				],
+				"formula": "2d4[acid]"
+			}
+		},
+		{
+			"name": "Mind Blank",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "system.traits.di.value",
+							"mode": "ADD",
+							"value": "psychic",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Mind Blank"
+				}
+			],
+			"system": {
+				"target.type": ""
+			},
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			}
 		},
 		{
 			"name": "Mind Sliver",
@@ -510,6 +1601,257 @@
 			}
 		},
 		{
+			"name": "Mirror Image",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "macro.tokenMagic",
+							"mode": "CUSTOM",
+							"value": "images",
+							"priority": 20
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Mirror Image"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			}
+		},
+		{
+			"name": "Otiluke's Resilient Sphere",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "system.attributes.movement.all",
+							"mode": "CUSTOM",
+							"value": "* 0.5",
+							"priority": "20"
+						},
+						{
+							"key": "system.traits.di.all",
+							"mode": "CUSTOM",
+							"value": "1",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Otiluke's Resilient Sphere"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			}
+		},
+		{
+			"name": "Otto's Irresistible Dance",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.disadvantage.ability.save.str",
+							"mode": "CUSTOM",
+							"value": "1",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.disadvantage.attack.all",
+							"mode": "CUSTOM",
+							"value": "1",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.grants.advantage.attack.all ",
+							"mode": "CUSTOM",
+							"value": "1",
+							"priority": "20"
+						},
+						{
+							"key": "macro.itemMacro",
+							"value": "",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"macroRepeat": "startEveryTurn"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Otto's Irresistible Dance"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			},
+			"_merge": {
+				"system": true
+			},
+			"itemMacro": {
+				"file": "PHB_otto's-irresistible-dance.js"
+			}
+		},
+		{
+			"name": "Pass without Trace",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "system.skills.ste.bonuses.check",
+							"mode": "ADD",
+							"value": "+ 10",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Pass without Trace"
+				}
+			],
+			"system": {
+				"target.value": null,
+				"target.units": null,
+				"target.type": "self"
+			},
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			}
+		},
+		{
+			"name": "Polymorph",
+			"source": "PHB",
+			"flags": {
+				"midiProperties": {
+					"autoFailFriendly": true
+				}
+			}
+		},
+		{
+			"name": "Psychic Scream",
+			"source": "XGE",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "macro.CE",
+							"mode": "CUSTOM",
+							"value": "Stunned",
+							"priority": 20
+						},
+						{
+							"key": "flags.midi-qol.OverTime",
+							"mode": "OVERRIDE",
+							"value": "label=Psychic Scream Stun (End of Turn),turn=end,saveDC=@attributes.spelldc,saveAbility=int,saveMagic=true,killAnim=true",
+							"priority": "20"
+						}
+					],
+					"duration": {
+						"rounds": 99
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Psychic Scream"
+				}
+			],
+			"system": {
+				"target.value": 10,
+				"target.units": null,
+				"target.type": "creature"
+			},
+			"flags": {
+				"midiProperties": {
+					"halfdam": true
+				},
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			}
+		},
+		{
+			"name": "Resistance",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.optional.resistance.label",
+							"mode": "CUSTOM",
+							"value": "Resistance",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.optional.resistance.save.all",
+							"mode": "CUSTOM",
+							"value": "+ 1d4",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"specialDuration": [
+								"isSave"
+							]
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Resistance"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			}
+		},
+		{
 			"name": "Sanctuary",
 			"source": "PHB",
 			"_TODO": [
@@ -534,6 +1876,64 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "Silence",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "macro.CE",
+							"mode": "CUSTOM",
+							"value": "Deafened",
+							"priority": 20
+						},
+						{
+							"key": "flags.midi-qol.fail.spell.vocal",
+							"mode": "OVERRIDE",
+							"value": "1",
+							"priority": "50"
+						},
+						{
+							"key": "system.traits.di.value",
+							"mode": "OVERRIDE",
+							"value": "thunder",
+							"priority": "50"
+						}
+					],
+					"duration": {
+						"seconds": 600
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						},
+						"ActiveAuras": {
+							"isAura": true,
+							"aura": "All",
+							"radius": 20,
+							"displayTemp": true
+						}
+					},
+					"name": "Silence",
+					"requires": {
+						"ActiveAuras": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[preActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_silence.js"
+			}
 		},
 		{
 			"name": "Silvery Barbs",
@@ -565,6 +1965,285 @@
 			]
 		},
 		{
+			"name": "Sleep",
+			"source": "PHB",
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"effects": [],
+			"itemMacro": {
+				"file": "PHB_sleep.js"
+			},
+			"system": {
+				"damage.parts": [
+					[
+						"5d8",
+						"midi-none"
+					]
+				]
+			}
+		},
+		{
+			"name": "Spike Growth",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "system.attributes.movement.walk",
+							"value": "0.5",
+							"mode": "MULTIPLY",
+							"priority": 30
+						},
+						{
+							"key": "macro.itemMacro",
+							"value": "",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"seconds": 600
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"specialDuration": [
+								"isMoved"
+							]
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						},
+						"ActiveAuras": {
+							"isAura": true,
+							"aura": "All",
+							"radius": 20,
+							"displayTemp": true
+						}
+					},
+					"name": "Spike Growth",
+					"requires": {
+						"ActiveAuras": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[preActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"system": {
+				"damage.parts": []
+			},
+			"itemMacro": {
+				"file": "PHB_spike-growth.js"
+			}
+		},
+		{
+			"name": "Spirit Guardians",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "system.attributes.movement.all",
+							"mode": "CUSTOM",
+							"value": "/2",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.OverTime",
+							"mode": "ADD",
+							"value": "turn=start,label=Spirit Guardians (Start of Turn),damageRoll=(@spellLevel)d8,damageType=radiant,saveRemove=false,saveDC=@attributes.spelldc,saveAbility=wis,saveDamage=halfdamage,killAnim=true",
+							"priority": "20"
+						},
+						{
+							"key": "macro.itemMacro",
+							"value": "@token @spellLevel @attributes.spelldc",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"selfTarget": true,
+							"selfTargetAlways": true
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						},
+						"ActiveAuras": {
+							"isAura": true,
+							"aura": "Enemy",
+							"radius": 15,
+							"ignoreSelf": true,
+							"displayTemp": true
+						}
+					},
+					"name": "Spirit Guardians",
+					"requires": {
+						"ActiveAuras": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_spirit-guardians.js"
+			},
+			"_merge": {
+				"system": true
+			},
+			"system": {
+				"target.value": null,
+				"target.units": null,
+				"target.type": "self",
+				"range.value": 15,
+				"range.units": "ft",
+				"actionType": "other",
+				"damage.parts": [],
+				"save.ability": null
+			}
+		},
+		{
+			"name": "Spirit Shroud",
+			"source": "TCE",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.spiritShroud",
+							"mode": "OVERRIDE",
+							"value": "@uuid",
+							"priority": 20
+						},
+						{
+							"key": "system.attributes.movement.all",
+							"mode": "CUSTOM",
+							"value": "-10",
+							"priority": "15"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"selfTarget": true,
+							"selfTargetAlways": true
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						},
+						"ActiveAuras": {
+							"isAura": true,
+							"aura": "Enemy",
+							"radius": 10,
+							"ignoreSelf": true,
+							"displayTemp": true
+						}
+					},
+					"name": "Spirit Shroud",
+					"requires": {
+						"ActiveAuras": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[preActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "TCE_spirit-shroud.js"
+			},
+			"system": {
+				"damage.parts": [],
+				"scaling.formula": "(floor(((@item.level) - 1) / 2))d8"
+			}
+		},
+		{
+			"name": "Storm Sphere",
+			"source": "XGE",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.disadvantage.skill.prc",
+							"mode": "ADD",
+							"value": "0",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.OverTime",
+							"mode": "CUSTOM",
+							"value": "turn=end,label=Storm Sphere (End of Turn),damageRoll=(@item.level - 2)d6,damageType=bludgeoning,saveRemove=false,saveDC=@attributes.spelldc,saveAbility=str,saveDamage=nodamage,killAnim=true",
+							"priority": "20"
+						},
+						{
+							"key": "macro.itemMacro",
+							"value": "",
+							"mode": "CUSTOM",
+							"priority": 20
+						}
+					],
+					"duration": {
+						"seconds": 60
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"macroRepeat": "startEveryTurn"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						},
+						"ActiveAuras": {
+							"isAura": true,
+							"aura": "All",
+							"radius": 20,
+							"save": "str",
+							"displayTemp": true
+						}
+					},
+					"name": "Storm Sphere",
+					"requires": {
+						"ActiveAuras": true
+					}
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[preActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "XGE_storm-sphere.js"
+			},
+			"_merge": {
+				"system": true
+			},
+			"system": {
+				"damage.parts": [
+					[
+						"2d6",
+						"bludgeoning"
+					]
+				],
+				"formula": "4d6[lightning]",
+				"actionType": "save"
+			}
+		},
+		{
 			"name": "Tasha's Caustic Brew",
 			"source": "TCE",
 			"effects": [
@@ -582,6 +2261,55 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "Thunderous Smite",
+			"source": "PHB",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.dnd5e.DamageBonusMacro",
+							"value": "ItemMacro.Thunderous Smite",
+							"mode": "CUSTOM",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.thunderousSmite.dc",
+							"value": "@attributes.spelldc",
+							"mode": "OVERRIDE",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"specialDuration": [
+								"1Hit:mwak"
+							],
+							"selfTarget": true,
+							"selfTargetAlways": true
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Thunderous Smite"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro,[preTargeting]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_thunderous-smite.js"
+			},
+			"system": {
+				"actionType": "other",
+				"damage.parts": []
+			}
 		},
 		{
 			"name": "Toll the Dead",
@@ -674,6 +2402,139 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "Vitriolic Sphere",
+			"source": "XGE",
+			"_merge": {
+				"system": true
+			},
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.OverTime",
+							"mode": "CUSTOM",
+							"value": "turn=end,label=Vitriolic Sphere (End of Turn),damageRoll=5d4,damageType=acid,removeCondition=true,killAnim=true",
+							"priority": "20"
+						}
+					],
+					"duration": {
+						"rounds": 1
+					},
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"specialDuration": [
+								"turnEnd"
+							]
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Vitriolic Sphere"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			}
+		},
+		{
+			"name": "Witch Bolt",
+			"source": "PHB",
+			"effects": [
+				{
+					"flags": {
+						"dae": {
+							"stackable": "noneName"
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Witch Bolt"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"onUseMacroName": "[postActiveEffects]ItemMacro",
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "PHB_witch-bolt.js"
+			}
+		},
+		{
+			"name": "Zephyr Strike",
+			"source": "XGE",
+			"effects": [
+				{
+					"changes": [
+						{
+							"key": "flags.midi-qol.optional.ZephyrStrike.macroToCall",
+							"mode": "CUSTOM",
+							"value": "ItemMacro.Zephyr Strike",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.optional.ZephyrStrike.damage.mwak",
+							"mode": "CUSTOM",
+							"value": "1d8[force - Additional damage on weapon attack]",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.optional.ZephyrStrike.damage.rwak",
+							"mode": "CUSTOM",
+							"value": "1d8[force - Additional damage on weapon attack]",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.optional.ZephyrStrike.count",
+							"mode": "CUSTOM",
+							"value": "1",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.optional.ZephyrStrike.label",
+							"mode": "CUSTOM",
+							"value": "Gain Zephyr Strike damage bonus?",
+							"priority": "20"
+						},
+						{
+							"key": "flags.midi-qol.optional.ZephyrStrike.criticalDamage",
+							"mode": "CUSTOM",
+							"value": "1",
+							"priority": "20"
+						}
+					],
+					"flags": {
+						"dae": {
+							"stackable": "noneName",
+							"selfTarget": true,
+							"selfTargetAlways": true
+						},
+						"midi-qol": {
+							"forceCEOff": true
+						}
+					},
+					"name": "Zephyr Strike"
+				}
+			],
+			"flags": {
+				"midi-qol": {
+					"forceCEOff": true
+				}
+			},
+			"itemMacro": {
+				"file": "XGE_zephyr-strike.js"
+			},
+			"system": {
+				"damage.parts": []
+			}
 		}
 	]
 }

--- a/module/js/Api.js
+++ b/module/js/Api.js
@@ -1,6 +1,7 @@
 import {SharedConsts} from "../shared/SharedConsts.js";
 import {DataManager} from "./DataManager.js";
 import {StartupHookMixin} from "./mixins/MixinStartupHooks.js";
+import DdbImporter from "./api/DdbImporter.js";
 
 /**
  * @mixes {StartupHookMixin}
@@ -13,4 +14,6 @@ export class Api extends StartupHookMixin(class {}) {
 	static pGetExpandedAddonData (opts) {
 		return DataManager.api_pGetExpandedAddonData(opts);
 	}
+
+	static DdbImporter = DdbImporter;
 }

--- a/module/js/api/DdbImporter.js
+++ b/module/js/api/DdbImporter.js
@@ -1,0 +1,293 @@
+// Helpers copied from D&D Beyond Importer's `helpers.js`
+// Credit to D&D Beyond Importer (https://github.com/MrPrimate/ddb-importer)
+// See: `../../../license/ddb-importer.md`
+
+/**
+ * If the requirements are met, returns true, false otherwise.
+ *
+ * @returns true if the requirements are met, false otherwise.
+ */
+export function requirementsSatisfied (name, dependencies) {
+	let missingDep = false;
+	dependencies.forEach((dep) => {
+		if (!game.modules.get(dep)?.active) {
+			const errorMsg = `${name}: ${dep} must be installed and active.`;
+			ui.notifications.error(errorMsg);
+			logger.warn(errorMsg);
+			missingDep = true;
+		}
+	});
+	return !missingDep;
+}
+
+/**
+ * If a custom AA condition animation exists for the specified name, registers the appropriate hook with AA
+ * to be able to replace the default condition animation by the custom one.
+ *
+ * @param {*} condition condition for which to replace its AA animation by a custom one (it must be a value from CONFIG.DND5E.conditionTypes).
+ * @param {*} macroData the midi-qol macro data.
+ * @param {*} originItemName the name of item used for AA customization of the condition.
+ * @param {*} conditionItemUuid the UUID of the item applying the condition.
+ */
+export function configureCustomAAForCondition (condition, macroData, originItemName, conditionItemUuid) {
+	// Get default condition label
+	const statusName = CONFIG.DND5E.conditionTypes[condition];
+	const customStatusName = `${statusName} [${originItemName}]`;
+	if (AutomatedAnimations.AutorecManager.getAutorecEntries().aefx.find((a) => (a.name ?? a.label) === customStatusName)) {
+		const aaHookId = Hooks.on("AutomatedAnimations-WorkflowStart", (data) => {
+			if (
+				data.item instanceof CONFIG.ActiveEffect.documentClass
+				&& (data.item.name ?? data.item.label) === statusName
+				&& data.item.origin === macroData.sourceItemUuid
+			) {
+				data.recheckAnimation = true;
+				if (isNewerVersion(game.version, 11)) {
+					data.item.name = customStatusName;
+				} else {
+					data.item.label = customStatusName;
+				}
+				Hooks.off("AutomatedAnimations-WorkflowStart", aaHookId);
+			}
+		});
+		// Make sure that the hook is removed when the special spell effect is completed
+		Hooks.once(`midi-qol.RollComplete.${conditionItemUuid}`, () => {
+			Hooks.off("AutomatedAnimations-WorkflowStart", aaHookId);
+		});
+	}
+}
+
+export function checkJB2a (free = true, patreon = true, notify = false) {
+	if (patreon && game.modules.get("jb2a_patreon")?.active) {
+		return true;
+	} else if (!free) {
+		if (notify) ui.notifications.error("This macro requires the patreon version of JB2A");
+		return false;
+	}
+	if (free && game.modules.get("JB2A_DnD5e")?.active) return true;
+	if (notify) ui.notifications.error("This macro requires either the patreon or free version of JB2A");
+	return false;
+}
+
+/**
+ * Adds a save advantage effect for the next save on the specified target actor.
+ *
+ * @param {*} targetActor the target actor on which to add the effect.
+ * @param {*} originItem the item that is the origin of the effect.
+ * @param {*} ability the short ability name to use for save, e.g. str
+ */
+export async function addSaveAdvantageToTarget (targetActor, originItem, ability, additionLabel = "", icon = null) {
+	const effectData = {
+		_id: randomID(),
+		changes: [
+			{
+				key: `flags.midi-qol.advantage.ability.save.${ability}`,
+				mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+				value: "1",
+				priority: 20,
+			},
+		],
+		origin: originItem.uuid,
+		disabled: false,
+		transfer: false,
+		icon,
+		duration: {turns: 1},
+		flags: {
+			dae: {
+				specialDuration: [`isSave.${ability}`],
+			},
+		},
+	};
+	if (isNewerVersion(game.version, 11)) {
+		effectData.name = `${originItem.name}${additionLabel}: Save Advantage`;
+	} else {
+		effectData.label = `${originItem.name}${additionLabel}: Save Advantage`;
+	}
+	await MidiQOL.socket().executeAsGM("createEffects", {actorUuid: targetActor.uuid, effects: [effectData]});
+}
+
+/**
+ * Returns ids of tokens in template
+ *
+ * @param {*} templateDoc the templatedoc to check
+ */
+export function findContainedTokensInTemplate (templateDoc) {
+	const contained = new Set();
+	for (const tokenDoc of templateDoc.parent.tokens) {
+		const startX = tokenDoc.width >= 1 ? 0.5 : tokenDoc.width / 2;
+		const startY = tokenDoc.height >= 1 ? 0.5 : tokenDoc.height / 2;
+		for (let x = startX; x < tokenDoc.width; x++) {
+			for (let y = startY; y < tokenDoc.width; y++) {
+				const curr = {
+					x: tokenDoc.x + (x * templateDoc.parent.grid.size) - templateDoc.x,
+					y: tokenDoc.y + (y * templateDoc.parent.grid.size) - templateDoc.y,
+				};
+				const contains = templateDoc.object.shape.contains(curr.x, curr.y);
+				if (contains) contained.add(tokenDoc.id);
+			}
+		}
+	}
+	return [...contained];
+}
+
+export async function checkTargetInRange ({sourceUuid, targetUuid, distance}) {
+	if (!game.modules.get("midi-qol")?.active) {
+		ui.notifications.error("checkTargetInRange requires midiQoL, not checking");
+		logger.error("checkTargetInRange requires midiQoL, not checking");
+		return true;
+	}
+	const sourceToken = await fromUuid(sourceUuid);
+	if (!sourceToken) return false;
+	const targetsInRange = MidiQOL.findNearby(null, sourceUuid, distance);
+	const isInRange = targetsInRange.reduce((result, possible) => {
+		const collisionRay = new Ray(sourceToken, possible);
+		const collision = canvas.walls.checkCollision(collisionRay, {mode: "any", type: "sight"});
+		if (possible.uuid === targetUuid && !collision) result = true;
+		return result;
+	}, false);
+	return isInRange;
+}
+
+/**
+ * Returns true if the attack is a ranged weapon attack that hit. It also supports melee weapons
+ * with the thrown property.
+ * @param {*} macroData the midi-qol macro data.
+ * @returns true if the attack is a ranged weapon attack that hit
+ */
+export function isRangedWeaponAttack (macroData) {
+	if (macroData.hitTargets.length < 1) {
+		return false;
+	}
+	if (macroData.item?.system.actionType === "rwak") {
+		return true;
+	}
+	if (macroData.item?.system.actionType !== "mwak" || !macroData.item?.system.properties?.thr) {
+		return false;
+	}
+
+	const sourceToken = canvas.tokens?.get(macroData.tokenId);
+	const targetToken = macroData.hitTargets[0].object;
+	const distance = MidiQOL.getDistance(sourceToken, targetToken, true, true);
+	const meleeDistance = 5; // Would it be possible to have creatures with reach and thrown weapon?
+	return distance >= 0 && distance > meleeDistance;
+}
+
+/**
+ * Selects all the tokens that are within X distance of the source token for the current game user.
+ * @param {Token} sourceToken the reference token from which to compute the distance.
+ * @param {number} distance the distance from the reference token.
+ * @param {boolean} includeSource flag to indicate if the reference token should be included or not in the selected targets.
+ * @returns an array of Token instances that were selected.
+ */
+export function selectTargetsWithinX (sourceToken, distance, includeSource) {
+	let aoeTargets = MidiQOL.findNearby(null, sourceToken, distance);
+	if (includeSource) {
+		aoeTargets.unshift(sourceToken);
+	}
+	const aoeTargetIds = aoeTargets.map((t) => t.document.id);
+	game.user?.updateTokenTargets(aoeTargetIds);
+	game.user?.broadcastActivity({aoeTargetIds});
+	return aoeTargets;
+}
+
+export async function attachSequencerFileToTemplate (templateUuid, sequencerFile, originUuid, scale = 1) {
+	if (game.modules.get("sequencer")?.active) {
+		if (Sequencer.Database.entryExists(sequencerFile)) {
+			logger.debug(`Trying to apply sequencer effect (${sequencerFile}) to ${templateUuid} from ${originUuid}`, sequencerFile);
+			const template = await fromUuid(templateUuid);
+			new Sequence()
+				.effect()
+				.file(Sequencer.Database.entryExists(sequencerFile))
+				.size({
+					width: canvas.grid.size * (template.width / canvas.dimensions.distance),
+					height: canvas.grid.size * (template.width / canvas.dimensions.distance),
+				})
+				.persist(true)
+				.origin(originUuid)
+				.belowTokens()
+				.opacity(0.5)
+				.attachTo(template, {followRotation: true})
+				.scaleToObject(scale)
+				.play();
+		}
+	}
+}
+
+/**
+ * Returns a new duration which reflects the remaining duration of the specified one.
+ *
+ * @param {*} duration the source duration
+ * @returns a new duration which reflects the remaining duration of the specified one.
+ */
+export function getRemainingDuration (duration) {
+	const newDuration = {};
+	if (duration.type === "seconds") {
+		newDuration.seconds = duration.remaining;
+	} else if (duration.type === "turns") {
+		const remainingRounds = Math.floor(duration.remaining);
+		const remainingTurns = (duration.remaining - remainingRounds) * 100;
+		newDuration.rounds = remainingRounds;
+		newDuration.turns = remainingTurns;
+	}
+	return newDuration;
+}
+
+export async function wait (ms) {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}
+
+export function getHighestAbility (actor, abilities) {
+	if (typeof abilities === "string") {
+		return abilities;
+	} else if (Array.isArray(abilities)) {
+		return abilities.reduce((prv, current) => {
+			if (actor.system.abilities[current].value > actor.system.abilities[prv].value) return current;
+			else return prv;
+		}, abilities[0]);
+	}
+	return undefined;
+}
+
+export function getCantripDice (actor) {
+	const level = actor.type === "character" ? actor.system.details.level : actor.system.details.cr;
+	return 1 + Math.floor((level + 1) / 6);
+}
+
+export async function createJB2aActors (subFolderName, name) {
+	const packKeys = ["jb2a_patreon.jb2a-actors", "JB2A_DnD5e.jb2a-actors"];
+	for (let key of packKeys) {
+		let pack = game.packs.get(key);
+		// eslint-disable-next-line no-continue
+		if (!pack) continue;
+		const actors = pack.index.filter((f) => f.name.includes(name));
+		const subFolder = await utils.getFolder("npc", subFolderName, "JB2A Actors", "#ceb180", "#cccc00", false);
+
+		for (const actor of actors) {
+			if (!game.actors.find((a) => a.name === actor.name && a.folder?.id === subFolder.id)) {
+				await game.actors.importFromCompendium(pack, actor._id, {
+					folder: subFolder.id,
+				});
+			}
+		}
+	}
+}
+
+export default {
+	effects: {
+		requirementsSatisfied,
+		configureCustomAAForCondition,
+		checkJB2a,
+		addSaveAdvantageToTarget,
+		findContainedTokensInTemplate,
+		checkTargetInRange,
+		isRangedWeaponAttack,
+		selectTargetsWithinX,
+		attachSequencerFileToTemplate,
+		getRemainingDuration,
+		wait,
+		getHighestAbility,
+		getCantripDice,
+		createJB2aActors,
+	},
+};

--- a/script/generate-item-macro-template.js
+++ b/script/generate-item-macro-template.js
@@ -3,6 +3,7 @@ import {Um} from "5etools-utils";
 import {Command} from "commander";
 import path from "path";
 import {DIR_ITEM_MACROS} from "./consts.js";
+import {getMacroFilename} from "../shared/util.js";
 
 const MACRO_TEMPLATE = `async function macro (args) {
 	// TODO write your macro here!
@@ -24,11 +25,7 @@ function main () {
 	const dirPath = path.join(DIR_ITEM_MACROS, params.dir);
 	fs.mkdirSync(dirPath, {recursive: true});
 
-	const filePath = path.join(
-		dirPath,
-		// FIXME better sluggification of `name`
-		`${params.source}_${params.name.toLowerCase().replace(/ /g, "-")}.js`,
-	);
+	const filePath = path.join(dirPath, getMacroFilename({name: params.name, source: params.source}));
 
 	if (fs.existsSync(filePath)) throw new Error(`File "${filePath}" already exists!`);
 

--- a/shared/foundry-helpers.js
+++ b/shared/foundry-helpers.js
@@ -1,0 +1,84 @@
+// Helpers copied from Foundry `helpers.mjs`; all credit to Foundry Gaming, LLC
+// Used under permissions granted by "Limited License for Package Development" (https://foundryvtt.com/article/license) :^)
+
+/**
+ * Learn the underlying data type of some variable. Supported identifiable types include:
+ * undefined, null, number, string, boolean, function, Array, Set, Map, Promise, Error,
+ * HTMLElement (client side only), Object (catchall for other object types)
+ * @param {*} variable  A provided variable
+ * @return {string}     The named type of the token
+ */
+export function getType(variable) {
+
+	// Primitive types, handled with simple typeof check
+	const typeOf = typeof variable;
+	if ( typeOf !== "object" ) return typeOf;
+
+	// Special cases of object
+	if ( variable === null ) return "null";
+	if ( !variable.constructor ) return "Object"; // Object with the null prototype.
+	if ( variable.constructor.name === "Object" ) return "Object";  // simple objects
+
+	// Match prototype instances
+	const prototypes = [
+		[Array, "Array"],
+		[Set, "Set"],
+		[Map, "Map"],
+		[Promise, "Promise"],
+		[Error, "Error"],
+		// [Color, "number"]
+	];
+	if ( "HTMLElement" in globalThis ) prototypes.push([globalThis.HTMLElement, "HTMLElement"]);
+	for ( const [cls, type] of prototypes ) {
+		if ( variable instanceof cls ) return type;
+	}
+
+	// Unknown Object type
+	return "Object";
+}
+
+/**
+ * Test whether a value is empty-like; either undefined or a content-less object.
+ * @param {*} value       The value to test
+ * @returns {boolean}     Is the value empty-like?
+ */
+export function isEmpty (value) {
+	const t = getType(value);
+	switch (t) {
+		case "undefined":
+			return true;
+		case "Array":
+			return !value.length;
+		case "Object":
+			return (getType(value) === "Object") && !Object.keys(value).length;
+		case "Set":
+		case "Map":
+			return !value.size;
+		default:
+			return false;
+	}
+}
+
+/**
+ * Flatten a possibly multi-dimensional object to a one-dimensional one by converting all nested keys to dot notation
+ * @param {object} obj        The object to flatten
+ * @param {number} [_d=0]     Track the recursion depth to prevent overflow
+ * @return {object}           A flattened object
+ */
+export function flattenObject (obj, _d = 0) {
+	const flat = {};
+	if (_d > 100) {
+		throw new Error("Maximum depth exceeded");
+	}
+	for (let [k, v] of Object.entries(obj)) {
+		let t = getType(v);
+		if (t === "Object") {
+			if (isEmpty(v)) flat[k] = v;
+			let inner = flattenObject(v, _d + 1);
+			for (let [ik, iv] of Object.entries(inner)) {
+				flat[`${k}.${ik}`] = iv;
+			}
+		} else flat[k] = v;
+	}
+	return flat;
+}

--- a/shared/util.js
+++ b/shared/util.js
@@ -1,0 +1,4 @@
+// FIXME better sluggification
+export const getSlugged = str => str.toLowerCase().replace(/ /g, "-");
+
+export const getMacroFilename = ({name, source}) => `${source}_${getSlugged(name)}.js`;

--- a/test/schema/shared.json
+++ b/test/schema/shared.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "shared.json",
-	"version": "0.7.0",
+	"version": "0.7.1",
 
 	"$defs": {
 		"schema": {
@@ -171,8 +171,7 @@
 				"effects": {
 					"type": "array",
 					"items": {"$ref": "#/$defs/effectObject"},
-					"uniqueItems": true,
-					"minItems": 1
+					"uniqueItems": true
 				},
 
 				"flags": {"$ref": "#/$defs/foundryFlagsObject"},
@@ -220,7 +219,7 @@
 
 				"_merge": {
 					"type": "object",
-					"description": "If our \"X\" (e.g. \"data\") should be merged with any base \"X\", rather than overwriting.",
+					"description": "If our \"X\" (e.g. \"system\") should be merged with any base \"X\", rather than overwriting.",
 					"properties": {
 						"system": {"const": true},
 						"chooseSystem": {"const": true},

--- a/tool/local-pages.js
+++ b/tool/local-pages.js
@@ -8,6 +8,7 @@ const port = 5001;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 app.use(express.static(path.join(__dirname, "..", "docs")));
+app.use("/shared/", express.static(path.join(__dirname, "..", "shared")));
 
 app.get("/", (req, res) => {
 	res.sendFile(path.join(__dirname, "..", "docs", "index.html"));


### PR DESCRIPTION
Here we fill in gaps left by CPR/MidiSRD, by grabbing available automations from the D&D Beyond Importer module. We do this, instead of depending on the module directly, for two reasons:

- DDBI, in code terms, is structured in such a way as to make pulling these automations out at runtime difficult. Viable options are limited to exceedingly flaky/dangerous big-`eval`s, or, having the user import everything from D&D Beyond in advance ( :^) ).
- DDBI represents a, to put it mildly, alternate workflow for importing content. Forcing the user into running both is bloaty at best.

As DDBI is regularly updated, keeping especially the macros in-sync is a task which will require future maintenance. Hopefully as other integrations advance, some of these spells will be automated elsewhere, and we can prune down the list of copies we're maintaining. In the meantime, additions have been made to the converter page to facilitate easy export of `system` data, and of item macros*.

In particular, some DDBI macros make use of a DDBI module API; a 1:1 port of this has therefore been made here (with renames to avoid any current and future collisions). As the references to this API are minimal and easy to find-replace, this solution seems "good enough" for the moment.

Regardless of potential future maintenance, various spells have seen basic automation improvements which should make for an all-round better experience moving forward.

* A future migration should likely be done to transition towards the new DAE "DIME" system, but this is work for another PR.